### PR TITLE
edge: push-based node join via shell-operator

### DIFF
--- a/hub/cluster/edge/asg/cloud-init-secret.yaml
+++ b/hub/cluster/edge/asg/cloud-init-secret.yaml
@@ -9,7 +9,6 @@ stringData:
     set -uexo pipefail
     export DEBIAN_FRONTEND=noninteractive
     curl -fsSL https://tailscale.com/install.sh | sh
-    tailscale up --accept-routes --login-server=https://headscale.tail22d0a0.ts.net --auth-key={{.TS_AUTH_KEY}}
     curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /' | tee /etc/apt/sources.list.d/kubernetes.list
     apt-get update
@@ -23,4 +22,3 @@ stringData:
     mkdir -p /etc/containerd
     containerd config default | sed 's/SystemdCgroup = false/SystemdCgroup = true/' > /etc/containerd/config.toml
     systemctl restart containerd.service
-    kubeadm join edge-apiserver.tailnet.hub.samcday.com:6443 --token {{.BOOTSTRAP_TOKEN}} --discovery-token-ca-cert-hash sha256:{{.CA_HASH}}

--- a/hub/cluster/edge/kustomization.yaml
+++ b/hub/cluster/edge/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - kustomizations.yaml
   - namespaces.yaml
   - node-bootstrap-token.yaml
+  - node-joiner
   - ts-apiserver.yaml
   - wasmcloud.yaml
   - wasmcloud-demo.yaml

--- a/hub/cluster/edge/node-joiner/deployment.yaml
+++ b/hub/cluster/edge/node-joiner/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: node-joiner
+  namespace: edge
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-joiner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-joiner
+    spec:
+      serviceAccountName: node-joiner
+      containers:
+        - name: shell-operator
+          image: ghcr.io/flant/shell-operator:v1.4.16
+          env:
+            - name: KUBECONFIG
+              value: /etc/edge-kubeconfig/kubeconfig
+            - name: SHELL_OPERATOR_HOOKS_DIR
+              value: /hooks
+            - name: SHELL_OPERATOR_TMP_DIR
+              value: /tmp/shell-operator
+            - name: LOG_LEVEL
+              value: info
+          volumeMounts:
+            - name: edge-kubeconfig
+              mountPath: /etc/edge-kubeconfig
+              readOnly: true
+            - name: hooks
+              mountPath: /hooks
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            requests: { cpu: 20m, memory: 64Mi }
+            limits:   { memory: 128Mi }
+      volumes:
+        - name: edge-kubeconfig
+          secret:
+            secretName: admin-kubeconfig
+            defaultMode: 0400
+            items:
+              - key: value
+                path: kubeconfig
+        - name: hooks
+          configMap:
+            name: node-joiner-hook
+            defaultMode: 0755
+        - name: tmp
+          emptyDir: {}

--- a/hub/cluster/edge/node-joiner/hook.sh
+++ b/hub/cluster/edge/node-joiner/hook.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--config" ]]; then
+  cat <<'YAML'
+configVersion: v1
+kubernetes:
+  - name: edge-nodes
+    apiVersion: v1
+    kind: Node
+    labelSelector:
+      matchExpressions:
+        - key: blc.samcday.com/asg
+          operator: Exists
+    executeHookOnEvent: [Added, Modified, Deleted]
+    executeHookOnSynchronization: true
+    jqFilter: |
+      {
+        name:  .metadata.name,
+        ip:    ((.status.addresses // []) | map(select(.type=="ExternalIP"))[0].address // ""),
+        ready: ((.status.conditions // []) | any(.type=="Ready" and .status=="True")),
+      }
+YAML
+  exit 0
+fi
+
+NAMESPACE=edge
+TEMPLATE=/hooks/job-template.yaml
+
+reconcile() {
+  local op=$1 name=$2 ip=$3 ready=$4
+  local job="join-$name"
+
+  if [[ -z "$name" ]]; then
+    return
+  fi
+
+  if [[ "$op" == "Deleted" || "$ready" == "true" ]]; then
+    kubectl -n "$NAMESPACE" delete job "$job" --ignore-not-found
+    return
+  fi
+
+  if [[ -z "$ip" ]]; then
+    echo "node $name: no ExternalIP yet, waiting for next event"
+    return
+  fi
+
+  if kubectl -n "$NAMESPACE" get job "$job" >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "creating join job for $name ($ip)"
+  local template manifest
+  template=$(<"$TEMPLATE")
+  manifest=${template//\$\{NODE_NAME\}/$name}
+  manifest=${manifest//\$\{NODE_IP\}/$ip}
+  kubectl -n "$NAMESPACE" create -f - <<<"$manifest"
+}
+
+jq -c '.[]' "$BINDING_CONTEXT_PATH" | while read -r row; do
+  type=$(jq -r '.type' <<<"$row")
+  case "$type" in
+    Synchronization)
+      jq -c '.objects[]? // empty' <<<"$row" | while read -r obj; do
+        reconcile "Synchronization" \
+          "$(jq -r '.filterResult.name  // ""'   <<<"$obj")" \
+          "$(jq -r '.filterResult.ip    // ""'   <<<"$obj")" \
+          "$(jq -r '.filterResult.ready // false' <<<"$obj")"
+      done
+      ;;
+    Event)
+      reconcile \
+        "$(jq -r '.watchEvent         // ""'    <<<"$row")" \
+        "$(jq -r '.filterResult.name  // ""'    <<<"$row")" \
+        "$(jq -r '.filterResult.ip    // ""'    <<<"$row")" \
+        "$(jq -r '.filterResult.ready // false' <<<"$row")"
+      ;;
+  esac
+done

--- a/hub/cluster/edge/node-joiner/job-template.yaml
+++ b/hub/cluster/edge/node-joiner/job-template.yaml
@@ -1,0 +1,77 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: join-${NODE_NAME}
+  labels:
+    app.kubernetes.io/component: node-joiner
+    bl.samcday.com/node: ${NODE_NAME}
+spec:
+  backoffLimit: 30
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: node-joiner
+        bl.samcday.com/node: ${NODE_NAME}
+    spec:
+      restartPolicy: OnFailure
+      volumes:
+        - name: edge-kubeconfig
+          secret:
+            secretName: admin-kubeconfig
+            defaultMode: 0400
+            items:
+              - key: value
+                path: kubeconfig
+      containers:
+        - name: join
+          image: alpine:3.21
+          env:
+            - name: NODE_IP
+              value: "${NODE_IP}"
+            - name: NODE_NAME
+              value: "${NODE_NAME}"
+            - name: TS_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: node-ts-auth
+                  key: key
+            - name: BOOTSTRAP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: bl-controllers-config
+                  key: token
+            - name: CA_HASH
+              valueFrom:
+                configMapKeyRef:
+                  name: ca-hash
+                  key: hash
+          volumeMounts:
+            - name: edge-kubeconfig
+              mountPath: /etc/edge-kubeconfig
+              readOnly: true
+          command: [/bin/sh, -c]
+          args:
+            - |
+              set -euo pipefail
+              apk add --no-cache openssh-client sshpass bash kubectl
+
+              NODE_PASSWORD=$(kubectl --kubeconfig=/etc/edge-kubeconfig/kubeconfig \
+                -n kube-system get secret "$NODE_NAME-node-password" \
+                -o jsonpath='{.data.password}' | base64 -d)
+
+              SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ConnectTimeout=10"
+
+              # cloud-init is still installing packages when SSH first comes up;
+              # retry until the node accepts a login.
+              until sshpass -p "$NODE_PASSWORD" ssh $SSH_OPTS "root@$NODE_IP" true; do
+                echo "waiting for sshd on $NODE_IP..."
+                sleep 10
+              done
+
+              sshpass -p "$NODE_PASSWORD" ssh $SSH_OPTS "root@$NODE_IP" bash -s <<EOF
+              set -euo pipefail
+              cloud-init status --wait
+              tailscale up --accept-routes --login-server=https://headscale.tail22d0a0.ts.net --auth-key=${TS_AUTH_KEY}
+              kubeadm join edge-apiserver.tailnet.hub.samcday.com:6443 --token ${BOOTSTRAP_TOKEN} --discovery-token-ca-cert-hash sha256:${CA_HASH}
+              EOF

--- a/hub/cluster/edge/node-joiner/kustomization.yaml
+++ b/hub/cluster/edge/node-joiner/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: edge
+resources:
+  - rbac.yaml
+  - deployment.yaml
+configMapGenerator:
+  - name: node-joiner-hook
+    files:
+      - hook.sh
+      - job-template.yaml

--- a/hub/cluster/edge/node-joiner/rbac.yaml
+++ b/hub/cluster/edge/node-joiner/rbac.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: node-joiner
+  namespace: edge
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: node-joiner
+  namespace: edge
+rules:
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [get, list, watch, create, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: node-joiner
+  namespace: edge
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: node-joiner
+subjects:
+  - kind: ServiceAccount
+    name: node-joiner
+    namespace: edge


### PR DESCRIPTION
Replace the (never-implemented) cloud-init templating pathway with a push-based join: cloud-init only installs tailscale + k8s packages, and a shell-operator deployment in hub's edge ns watches edge Nodes and creates a per-Node Job that SSHes in, waits for cloud-init, runs tailscale up, and kubeadm joins. Secrets stay in Kubernetes instead of baked into the user-data BinaryLane holds.

shell-operator watches edge via the admin-kubeconfig; hook scripts act against hub in-cluster. Jobs fetch the per-node SSH password from edge kube-system at runtime using the same kubeconfig.