### PR TITLE
Stage Fabric-hosted lab control plane

### DIFF
--- a/charts/k8s-control-plane/files/admin-kubeconfig-generator.yaml
+++ b/charts/k8s-control-plane/files/admin-kubeconfig-generator.yaml
@@ -1,8 +1,24 @@
 template:
+  {{- if $.Values.parentWorkloads.enabled }}
+  metadata:
+    labels:
+      {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "admin-kubeconfig-generator") | nindent 6 }}
+  {{- end }}
   spec:
+    {{- include "k8s-control-plane.parent-pod-spec" (dict "root" $ "component" "admin-kubeconfig-generator") | nindent 4 }}
     containers:
       - name: admin-kubeconfig-generator
         image: {{ include "k8s-control-plane.kubectl-image" $ }}
+        {{- with $.Values.utilities.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" (dict)) | nindent 8 }}
+        {{- if $.Values.utilities.writableTmp }}
+        env:
+          - name: HOME
+            value: /tmp
+        {{- end }}
         command:
           - bash
           - -uexo
@@ -61,6 +77,10 @@ template:
           - name: kubeconfig-external
             mountPath: /kubeconfig-external
             subPath: kubeconfig
+          {{- if $.Values.utilities.writableTmp }}
+          - name: tmp
+            mountPath: /tmp
+          {{- end }}
           {{- range $user := $.Values.users }}
           {{- $userName := required "users[].name is required" $user.name }}
           {{- $certSecretName := printf "user-%s" $userName }}
@@ -84,6 +104,10 @@ template:
       - name: kubeconfig-external
         configMap:
           name: kubeconfig-external
+      {{- if $.Values.utilities.writableTmp }}
+      - name: tmp
+        emptyDir: {}
+      {{- end }}
       {{- range $user := $.Values.users }}
       {{- $userName := required "users[].name is required" $user.name }}
       {{- $certSecretName := printf "user-%s" $userName }}

--- a/charts/k8s-control-plane/files/cluster-bootstrap.yaml
+++ b/charts/k8s-control-plane/files/cluster-bootstrap.yaml
@@ -24,7 +24,7 @@ metadata:
   namespace: kube-system
 data:
   ClusterConfiguration: |
-    apiVersion: kubeadm.k8s.io/v1beta3
+    apiVersion: {{ $.Values.bootstrap.kubeadmAPIVersion }}
     kind: ClusterConfiguration
     clusterName: {{ $.Values.clusterName }}
     kubernetesVersion: v{{ $.Values.version }}
@@ -115,6 +115,23 @@ rules:
   - get
 ---
 {{- if $.Values.konnectivity.enabled }}
+{{- if eq $.Values.konnectivity.server.clientIdentity "dedicated" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:konnectivity-server
+  labels:
+    kubernetes.io/cluster-service: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: system:konnectivity-server
+---
+{{- end }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/k8s-control-plane/templates/NOTES.txt
+++ b/charts/k8s-control-plane/templates/NOTES.txt
@@ -10,6 +10,6 @@ A control-plane for the cluster "{{ $.Values.clusterName }}" has been deployed. 
 {{- if (empty (default (list) $.Values.serviceCIDRs)) -}}
 {{- fail "missing serviceCIDRs" -}}
 {{- end -}}
-{{- if (gt 2 (len $.Values)) -}}
+{{- if (gt (len $.Values.serviceCIDRs) 2) -}}
 {{- fail "too many serviceCIDRs" -}}
 {{- end -}}

--- a/charts/k8s-control-plane/templates/_helpers.tpl
+++ b/charts/k8s-control-plane/templates/_helpers.tpl
@@ -1,3 +1,116 @@
 {{- define "k8s-control-plane.kubectl-image" -}}
-bitnamilegacy/kubectl:1.33.4
+{{- required "missing utilities.image" $.Values.utilities.image -}}
+{{- end }}
+
+{{- define "k8s-control-plane.component-image" -}}
+{{- $image := .image -}}
+{{- $root := .root -}}
+{{- printf "%s:%s" (required "missing image.repository" $image.repository) (tpl (required "missing image.tag" $image.tag) $root) -}}
+{{- with $image.digest -}}@{{ . }}{{- end -}}
+{{- end }}
+
+{{- define "k8s-control-plane.stable-labels" -}}
+app.kubernetes.io/name: {{ .root.Chart.Name | quote }}
+app.kubernetes.io/instance: {{ .root.Release.Name | quote }}
+app.kubernetes.io/component: {{ .component | quote }}
+{{- end }}
+
+{{- define "k8s-control-plane.container-security-context" -}}
+{{- $securityContext := dict -}}
+{{- if .root.Values.parentWorkloads.enabled -}}
+{{- $securityContext = deepCopy (default (dict) .root.Values.parentWorkloads.containerSecurityContext) -}}
+{{- end -}}
+{{- $securityContext = mustMergeOverwrite $securityContext (default (dict) .securityContext) -}}
+{{- with $securityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end -}}
+{{- end }}
+
+{{- define "k8s-control-plane.parent-pod-spec" -}}
+{{- $root := .root -}}
+{{- if $root.Values.parentWorkloads.enabled -}}
+{{- $parent := $root.Values.parentWorkloads -}}
+{{- $isDeployment := default false .deployment -}}
+{{- if default false .disableServiceAccountToken }}
+automountServiceAccountToken: false
+{{- end }}
+{{- with $parent.podSecurityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $parent.placement.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with $parent.placement.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- $affinity := deepCopy (default (dict) $parent.placement.affinity) -}}
+{{- if and $isDeployment $parent.deployment.requiredPodAntiAffinityTopologyKey -}}
+{{- $podAntiAffinity := deepCopy (default (dict) (get $affinity "podAntiAffinity")) -}}
+{{- $required := default (list) (get $podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution") -}}
+{{- $term := dict "labelSelector" (dict "matchLabels" (dict "app.kubernetes.io/name" $root.Chart.Name "app.kubernetes.io/instance" $root.Release.Name "app.kubernetes.io/component" .component)) "topologyKey" $parent.deployment.requiredPodAntiAffinityTopologyKey -}}
+{{- $_ := set $podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution" (append $required $term) -}}
+{{- $_ := set $affinity "podAntiAffinity" $podAntiAffinity -}}
+{{- end }}
+{{- with $affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if $isDeployment }}
+{{- with $parent.deployment.priorityClassName }}
+priorityClassName: {{ . | quote }}
+{{- end }}
+{{- if ne $parent.deployment.terminationGracePeriodSeconds nil }}
+terminationGracePeriodSeconds: {{ $parent.deployment.terminationGracePeriodSeconds }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "k8s-control-plane.parent-deployment-spec" -}}
+{{- if .Values.parentWorkloads.enabled -}}
+{{- with .Values.parentWorkloads.deployment.strategy }}
+strategy:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+minReadySeconds: {{ .Values.parentWorkloads.deployment.minReadySeconds }}
+{{- end }}
+{{- end }}
+
+{{- define "k8s-control-plane.validate" -}}
+{{- $validDigest := "^sha256:[0-9a-f]{64}$" -}}
+{{- range $name, $image := dict "apiServer" .Values.apiServer.image "controllerManager" .Values.controllerManager.image "scheduler" .Values.scheduler.image -}}
+{{- if and $image.digest (not (regexMatch $validDigest $image.digest)) -}}
+{{- fail (printf "%s.image.digest must be sha256:<64 lowercase hex characters>" $name) -}}
+{{- end -}}
+{{- end -}}
+{{- if not (has .Values.bootstrap.kubeadmAPIVersion (list "kubeadm.k8s.io/v1beta3" "kubeadm.k8s.io/v1beta4")) -}}
+{{- fail "bootstrap.kubeadmAPIVersion must be kubeadm.k8s.io/v1beta3 or kubeadm.k8s.io/v1beta4" -}}
+{{- end -}}
+{{- if not (has .Values.konnectivity.server.clientIdentity (list "legacyAdmin" "dedicated")) -}}
+{{- fail "konnectivity.server.clientIdentity must be legacyAdmin or dedicated" -}}
+{{- end -}}
+{{- if and (not .Values.konnectivity.enabled) (eq .Values.konnectivity.server.clientIdentity "dedicated") -}}
+{{- fail "konnectivity.server.clientIdentity=dedicated requires konnectivity.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.parentWorkloads.deployment.pdb.enabled (not .Values.parentWorkloads.enabled) -}}
+{{- fail "parentWorkloads.deployment.pdb.enabled requires parentWorkloads.enabled=true" -}}
+{{- end -}}
+{{- if .Values.parentWorkloads.deployment.pdb.enabled -}}
+{{- $pdbSpec := .Values.parentWorkloads.deployment.pdb.spec -}}
+{{- if hasKey $pdbSpec "selector" -}}
+{{- fail "do not set parentWorkloads.deployment.pdb.spec.selector" -}}
+{{- end -}}
+{{- $hasMin := hasKey $pdbSpec "minAvailable" -}}
+{{- $hasMax := hasKey $pdbSpec "maxUnavailable" -}}
+{{- if eq $hasMin $hasMax -}}
+{{- fail "parentWorkloads.deployment.pdb.spec must set exactly one of minAvailable or maxUnavailable" -}}
+{{- end -}}
+{{- end -}}
+{{- if and .Values.parentWorkloads.enabled (dig "readOnlyRootFilesystem" false .Values.parentWorkloads.containerSecurityContext) (not .Values.utilities.writableTmp) -}}
+{{- fail "utilities.writableTmp=true is required when parentWorkloads.containerSecurityContext.readOnlyRootFilesystem=true" -}}
+{{- end -}}
 {{- end }}

--- a/charts/k8s-control-plane/templates/admin-kubeconfig.yaml
+++ b/charts/k8s-control-plane/templates/admin-kubeconfig.yaml
@@ -3,8 +3,15 @@ apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: admin-kubeconfig-generator
+  {{- if $.Values.parentWorkloads.enabled }}
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "admin-kubeconfig-generator") | nindent 4 }}
+  {{- end }}
 spec:
-  schedule: "@weekly"
+  schedule: {{ required "missing adminKubeconfig.schedule" $.Values.adminKubeconfig.schedule | quote }}
+  {{- with $.Values.adminKubeconfig.concurrencyPolicy }}
+  concurrencyPolicy: {{ . }}
+  {{- end }}
   jobTemplate:
     spec:
       {{- toYaml $jobSpec | nindent 6 }}
@@ -13,6 +20,12 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: admin-kubeconfig-generator
+  {{- if $.Values.parentWorkloads.enabled }}
+  annotations:
+    helm.toolkit.fluxcd.io/driftDetection: disabled
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "admin-kubeconfig-generator") | nindent 4 }}
+  {{- end }}
 spec:
   {{- toYaml $jobSpec | nindent 2 }}
 ---

--- a/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
+++ b/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
@@ -2,13 +2,38 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: advertise-address 
+  name: advertise-address
+  {{- if $.Values.parentWorkloads.enabled }}
+  annotations:
+    helm.toolkit.fluxcd.io/driftDetection: disabled
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "advertise-address") | nindent 4 }}
+  {{- end }}
 spec:
   template:
+    {{- if $.Values.parentWorkloads.enabled }}
+    metadata:
+      labels:
+        {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "advertise-address") | nindent 8 }}
+    {{- end }}
     spec:
+      {{- include "k8s-control-plane.parent-pod-spec" (dict "root" $ "component" "advertise-address") | nindent 6 }}
       containers:
         - name: advertise-address
           image: {{ include "k8s-control-plane.kubectl-image" $ }}
+          {{- with $.Values.utilities.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" (dict)) | nindent 10 }}
+          {{- if $.Values.utilities.writableTmp }}
+          env:
+            - name: HOME
+              value: /tmp
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- end }}
           command:
             - bash
             - -uexo
@@ -27,6 +52,11 @@ spec:
               kubectl patch cert apiserver --type merge -p "{\"spec\":{\"ipAddresses\":[\"$ip\",\"{{ $.Values.serviceIP }}\"]}}"
       serviceAccount: advertise-address
       restartPolicy: OnFailure
+      {{- if $.Values.utilities.writableTmp }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      {{- end }}
   ttlSecondsAfterFinished: 60
 ---
 apiVersion: v1

--- a/charts/k8s-control-plane/templates/apiserver/apiserver.yaml
+++ b/charts/k8s-control-plane/templates/apiserver/apiserver.yaml
@@ -18,7 +18,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: apiserver
+  {{- if $.Values.parentWorkloads.enabled }}
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "apiserver") | nindent 4 }}
+  {{- end }}
 spec:
+  {{- include "k8s-control-plane.parent-deployment-spec" $ | nindent 2 }}
   replicas: {{ required "missing apiServer.replicas" $.Values.apiServer.replicas }}
   selector:
     matchLabels:
@@ -36,16 +41,22 @@ spec:
       {{- end }}
       labels:
         app: apiserver
+        {{- if $.Values.parentWorkloads.enabled }}
+        {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "apiserver") | nindent 8 }}
+        {{- end }}
     spec:
+      {{- include "k8s-control-plane.parent-pod-spec" (dict "root" $ "component" "apiserver" "deployment" true "disableServiceAccountToken" true) | nindent 6 }}
       containers:
-        - image: {{ with $.Values.apiServer.image -}}
-                   {{- required "missing apiServer.image.repository" .repository }}:
-                   {{- tpl (required "missing apiServer.image.tag" .tag) $ -}}
-                 {{ end }}
+        - image: {{ include "k8s-control-plane.component-image" (dict "root" $ "image" $.Values.apiServer.image) }}
           {{- with $.Values.apiServer.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
           name: apiserver
+          {{- with $.Values.apiServer.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" $.Values.apiServer.securityContext) | nindent 10 }}
           command:
             - kube-apiserver
             {{- if $.Values.externalIP }}
@@ -164,9 +175,21 @@ spec:
             - --mode=grpc
             - --agent-namespace=kube-system
             - --agent-service-account=konnectivity-agent
+            {{- if eq $.Values.konnectivity.server.clientIdentity "dedicated" }}
+            - --kubeconfig=/konnectivity-kubeconfig
+            {{- else }}
             - --kubeconfig=/kubeconfig
+            {{- end }}
             - --authentication-audience=system:konnectivity-server
             - --server-count={{ $.Values.apiServer.replicas }}
+            {{- range $.Values.konnectivity.server.extraArgs }}
+            - {{ tpl . $ | quote }}
+            {{- end }}
+          {{- with $.Values.konnectivity.server.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" (dict)) | nindent 10 }}
           livenessProbe:
             httpGet:
               port: 8092
@@ -174,15 +197,26 @@ spec:
             initialDelaySeconds: 10
             timeoutSeconds: 60
           volumeMounts:
+            {{- if eq $.Values.konnectivity.server.clientIdentity "dedicated" }}
+            - name: konnectivity-client
+              mountPath: /konnectivity-client
+            {{- else }}
             - name: admin
               mountPath: /cert
+            {{- end }}
             - name: cert
               mountPath: /apiserver-cert
             - name: konnectivity
               mountPath: /konnectivity
+            {{- if eq $.Values.konnectivity.server.clientIdentity "dedicated" }}
+            - name: konnectivity-kubeconfig
+              mountPath: /konnectivity-kubeconfig
+              subPath: kubeconfig
+            {{- else }}
             - name: kubeconfig
               mountPath: /kubeconfig
               subPath: kubeconfig
+            {{- end }}
         {{- end }}
       volumes:
         - name: cert
@@ -209,6 +243,14 @@ spec:
         - name: kubeconfig
           configMap:
             name: kubeconfig
+        {{- if eq $.Values.konnectivity.server.clientIdentity "dedicated" }}
+        - name: konnectivity-client
+          secret:
+            secretName: konnectivity-server
+        - name: konnectivity-kubeconfig
+          configMap:
+            name: konnectivity-server-kubeconfig
+        {{- end }}
         {{ end }}
 ---
 {{ if $.Values.konnectivity.enabled }}
@@ -234,6 +276,7 @@ data:
               uds:
                 udsName: /konnectivity/socket
 ---
+{{- if eq $.Values.konnectivity.server.clientIdentity "legacyAdmin" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -249,4 +292,5 @@ subjects:
     kind: User
     name: system:konnectivity-server
 ---
+{{- end }}
 {{ end }}

--- a/charts/k8s-control-plane/templates/apiserver/cert-konnectivity-server.yaml
+++ b/charts/k8s-control-plane/templates/apiserver/cert-konnectivity-server.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.konnectivity.enabled (eq .Values.konnectivity.server.clientIdentity "dedicated") -}}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: konnectivity-server
+spec:
+  commonName: system:konnectivity-server
+  duration: 336h
+  issuerRef:
+    name: ca
+    kind: Issuer
+  secretName: konnectivity-server
+  usages: [client auth]
+{{- end -}}

--- a/charts/k8s-control-plane/templates/apiserver/podmonitor.yaml
+++ b/charts/k8s-control-plane/templates/apiserver/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.monitoring.podMonitors.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -33,3 +34,4 @@ spec:
   selector:
     matchLabels:
       app: apiserver
+{{- end -}}

--- a/charts/k8s-control-plane/templates/bootstrap.yaml
+++ b/charts/k8s-control-plane/templates/bootstrap.yaml
@@ -2,12 +2,29 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: bootstrap
+  {{- if $.Values.parentWorkloads.enabled }}
+  annotations:
+    helm.toolkit.fluxcd.io/driftDetection: disabled
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "bootstrap") | nindent 4 }}
+  {{- end }}
 spec:
   template:
+    {{- if $.Values.parentWorkloads.enabled }}
+    metadata:
+      labels:
+        {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "bootstrap") | nindent 8 }}
+    {{- end }}
     spec:
+      {{- include "k8s-control-plane.parent-pod-spec" (dict "root" $ "component" "bootstrap" "disableServiceAccountToken" true) | nindent 6 }}
       containers:
         - name: bootstrap
           image: {{ include "k8s-control-plane.kubectl-image" $ }}
+          {{- with $.Values.utilities.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" (dict)) | nindent 10 }}
           command:
             - bash
             - -uexo
@@ -22,12 +39,20 @@ spec:
           env:
             - name: KUBECONFIG
               value: /kubeconfig
+            {{- if $.Values.utilities.writableTmp }}
+            - name: HOME
+              value: /tmp
+            {{- end }}
           volumeMounts:
             - name: cert
               mountPath: /cert
             - name: kubeconfig
               mountPath: /kubeconfig
               subPath: kubeconfig
+            {{- if $.Values.utilities.writableTmp }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
       volumes:
         - name: cert
           secret:
@@ -35,5 +60,9 @@ spec:
         - name: kubeconfig
           configMap:
             name: kubeconfig
+        {{- if $.Values.utilities.writableTmp }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
       restartPolicy: OnFailure
   ttlSecondsAfterFinished: 60

--- a/charts/k8s-control-plane/templates/ca-hash.yaml
+++ b/charts/k8s-control-plane/templates/ca-hash.yaml
@@ -2,12 +2,34 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: ca-hash
+  {{- if $.Values.parentWorkloads.enabled }}
+  annotations:
+    helm.toolkit.fluxcd.io/driftDetection: disabled
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "ca-hash") | nindent 4 }}
+  {{- end }}
 spec:
   template:
+    {{- if $.Values.parentWorkloads.enabled }}
+    metadata:
+      labels:
+        {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "ca-hash") | nindent 8 }}
+    {{- end }}
     spec:
+      {{- include "k8s-control-plane.parent-pod-spec" (dict "root" $ "component" "ca-hash") | nindent 6 }}
       containers:
         - name: ca-hash
           image: {{ include "k8s-control-plane.kubectl-image" $ }}
+          {{- with $.Values.utilities.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" (dict)) | nindent 10 }}
+          {{- if $.Values.utilities.writableTmp }}
+          env:
+            - name: HOME
+              value: /tmp
+          {{- end }}
           command:
             - bash
             - -uexo
@@ -21,12 +43,20 @@ spec:
             - name: ca
               mountPath: /ca.crt
               subPath: tls.crt
+            {{- if $.Values.utilities.writableTmp }}
+            - name: tmp
+              mountPath: /tmp
+            {{- end }}
       serviceAccount: ca-hash
       restartPolicy: OnFailure
       volumes:
         - name: ca
           secret:
             secretName: ca
+        {{- if $.Values.utilities.writableTmp }}
+        - name: tmp
+          emptyDir: {}
+        {{- end }}
   ttlSecondsAfterFinished: 60
 ---
 apiVersion: v1

--- a/charts/k8s-control-plane/templates/controller/controller-manager.yaml
+++ b/charts/k8s-control-plane/templates/controller/controller-manager.yaml
@@ -2,7 +2,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
+  {{- if $.Values.parentWorkloads.enabled }}
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "controller-manager") | nindent 4 }}
+  {{- end }}
 spec:
+  {{- include "k8s-control-plane.parent-deployment-spec" $ | nindent 2 }}
   replicas: {{ required "missing controllerManager.replicas" $.Values.controllerManager.replicas }}
   selector:
     matchLabels:
@@ -11,16 +16,22 @@ spec:
     metadata:
       labels:
         app: kube-controller-manager
+        {{- if $.Values.parentWorkloads.enabled }}
+        {{- include "k8s-control-plane.stable-labels" (dict "root" $ "component" "controller-manager") | nindent 8 }}
+        {{- end }}
     spec:
+      {{- include "k8s-control-plane.parent-pod-spec" (dict "root" $ "component" "controller-manager" "deployment" true "disableServiceAccountToken" true) | nindent 6 }}
       containers:
-        - image: {{ with $.Values.controllerManager.image -}}
-                   {{- required "missing controllerManager.image.repository" .repository }}:
-                   {{- tpl (required "missing controllerManager.image.tag" .tag) $ -}}
-                 {{ end }}
+        - image: {{ include "k8s-control-plane.component-image" (dict "root" $ "image" $.Values.controllerManager.image) }}
           {{- with $.Values.controllerManager.image.pullPolicy }}
           imagePullPolicy: {{ . }}
           {{- end }}
           name: controller-manager
+          {{- with $.Values.controllerManager.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" $.Values.controllerManager.securityContext) | nindent 10 }}
           command:
             - kube-controller-manager
             - --allocate-node-cidrs=true

--- a/charts/k8s-control-plane/templates/controller/podmonitor.yaml
+++ b/charts/k8s-control-plane/templates/controller/podmonitor.yaml
@@ -1,3 +1,4 @@
+{{- if $.Values.monitoring.podMonitors.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -23,3 +24,4 @@ spec:
   selector:
     matchLabels:
       app: kube-controller-manager
+{{- end -}}

--- a/charts/k8s-control-plane/templates/kubeconfig.yaml
+++ b/charts/k8s-control-plane/templates/kubeconfig.yaml
@@ -23,6 +23,34 @@ data:
             user:
               client-certificate: /cert/tls.crt
               client-key: /cert/tls.key
+{{- if and $.Values.konnectivity.enabled (eq $.Values.konnectivity.server.clientIdentity "dedicated") }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: konnectivity-server-kubeconfig
+data:
+  kubeconfig: |
+    apiVersion: v1
+    clusters:
+      - cluster:
+          certificate-authority: /konnectivity-client/ca.crt
+          server: https://apiserver.{{ $.Release.Namespace }}.svc.{{ $.Values.parentClusterDomain }}:6443
+        name: {{ $.Values.clusterName }}
+    contexts:
+      - context:
+          cluster: {{ $.Values.clusterName }}
+          user: system:konnectivity-server
+        name: system:konnectivity-server@{{ $.Values.clusterName }}
+    current-context: system:konnectivity-server@{{ $.Values.clusterName }}
+    kind: Config
+    preferences: {}
+    users:
+      - name: system:konnectivity-server
+        user:
+          client-certificate: /konnectivity-client/tls.crt
+          client-key: /konnectivity-client/tls.key
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/k8s-control-plane/templates/pdb.yaml
+++ b/charts/k8s-control-plane/templates/pdb.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.parentWorkloads.enabled .Values.parentWorkloads.deployment.pdb.enabled -}}
+{{- $root := . -}}
+{{- $workloads := list (dict "name" "apiserver" "component" "apiserver") (dict "name" "controller-manager" "component" "controller-manager") -}}
+{{- if .Values.scheduler.enabled -}}
+{{- $workloads = append $workloads (dict "name" "kube-scheduler" "component" "scheduler") -}}
+{{- end -}}
+{{- range $workload := $workloads }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $workload.name }}
+  labels:
+    {{- include "k8s-control-plane.stable-labels" (dict "root" $root "component" $workload.component) | nindent 4 }}
+spec:
+  {{- toYaml $root.Values.parentWorkloads.deployment.pdb.spec | nindent 2 }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $root.Chart.Name | quote }}
+      app.kubernetes.io/instance: {{ $root.Release.Name | quote }}
+      app.kubernetes.io/component: {{ $workload.component | quote }}
+---
+{{- end -}}
+{{- end -}}

--- a/charts/k8s-control-plane/templates/scheduler/podmonitor.yaml
+++ b/charts/k8s-control-plane/templates/scheduler/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.scheduler.enabled -}}
+{{- if and $.Values.scheduler.enabled $.Values.monitoring.podMonitors.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/k8s-control-plane/templates/scheduler/scheduler.yaml
+++ b/charts/k8s-control-plane/templates/scheduler/scheduler.yaml
@@ -1,10 +1,14 @@
 {{- define "scheduler-container" -}}
 name: kube-scheduler
 {{- with $.Values.scheduler.image }}
-image: {{ required "missing scheduler.image.repository" .repository }}:
-        {{- tpl (required "missing scheduler.image.tag" .tag) $ }}
+image: {{ include "k8s-control-plane.component-image" (dict "root" $ "image" .) }}
 imagePullPolicy: {{ .pullPolicy }}
 {{- end }}
+{{- with $.Values.scheduler.resources }}
+resources:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- include "k8s-control-plane.container-security-context" (dict "root" $ "securityContext" $.Values.scheduler.securityContext) }}
 command:
   - kube-scheduler
   - --authentication-kubeconfig=/kubeconfig
@@ -61,10 +65,26 @@ volumes:
 {{- $dep := $.Values.scheduler.deployment -}}
 {{- $spec := $dep.spec -}}
 {{- $barfSpec := omit $spec "replicas" "selector" "template" -}}
+{{- $parentDeploymentSpec := dict -}}
+{{- if $.Values.parentWorkloads.enabled -}}
+{{- $parentDeploymentSpec = fromYaml (include "k8s-control-plane.parent-deployment-spec" $) -}}
+{{- end -}}
+{{- $mergedDeploymentSpec := deepCopy $parentDeploymentSpec -}}
+{{- range $key, $value := $barfSpec -}}
+{{- $_ := set $mergedDeploymentSpec $key $value -}}
+{{- end -}}
 
 {{- $template := default (dict) $spec.template -}}
 {{- $templateSpec := default (dict) $template.spec -}}
 {{- $barfTemplate := omit $templateSpec "containers" "volumes" -}}
+{{- $parentPodSpec := dict -}}
+{{- if $.Values.parentWorkloads.enabled -}}
+{{- $parentPodSpec = fromYaml (include "k8s-control-plane.parent-pod-spec" (dict "root" $ "component" "scheduler" "deployment" true "disableServiceAccountToken" true)) -}}
+{{- end -}}
+{{- $mergedPodSpec := deepCopy $parentPodSpec -}}
+{{- range $key, $value := $barfTemplate -}}
+{{- $_ := set $mergedPodSpec $key $value -}}
+{{- end -}}
 
 {{- $container := fromYaml (include "scheduler-container" $) -}}
 
@@ -82,6 +102,17 @@ volumes:
 
 {{- $containers := list ($container) -}}
 {{- $volumes := (fromYaml (include "scheduler-volumes" $)).volumes -}}
+{{- $deploymentLabels := deepCopy (default (dict) $dep.labels) -}}
+{{- if $.Values.parentWorkloads.enabled -}}
+{{- $deploymentLabels = mustMergeOverwrite (fromYaml (include "k8s-control-plane.stable-labels" (dict "root" $ "component" "scheduler"))) $deploymentLabels -}}
+{{- end -}}
+{{- $podLabels := dict "app" "kube-scheduler" -}}
+{{- if $.Values.parentWorkloads.enabled -}}
+{{- $podLabels = mustMergeOverwrite $podLabels (fromYaml (include "k8s-control-plane.stable-labels" (dict "root" $ "component" "scheduler"))) -}}
+{{- end -}}
+{{- $podLabels = mustMergeOverwrite $podLabels (dig "metadata" "labels" (dict) $template) -}}
+{{- $podAnnotations := dict "config-hash" (sha1sum (print (toYaml $.Values.scheduler.config) (dig "deployment" "spec" "strategy" "type" "" $.Values.scheduler) (dig "deployment" "spec" "replicas" 1 $.Values.scheduler))) -}}
+{{- $podAnnotations = mustMergeOverwrite $podAnnotations (dig "metadata" "annotations" (dict) $template) -}}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -91,13 +122,13 @@ metadata:
   annotations:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
-  {{- with $dep.labels }}
+  {{- with $deploymentLabels }}
   labels:
     {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
-  {{- if not (empty $barfSpec) }}
-  {{- $barfSpec | toYaml | nindent 2 }}
+  {{- if not (empty $mergedDeploymentSpec) }}
+  {{- $mergedDeploymentSpec | toYaml | nindent 2 }}
   {{- end }}
   replicas: {{ required "missing scheduler.deployment.spec.replicas" $spec.replicas }}
   selector:
@@ -106,15 +137,9 @@ spec:
   template:
     metadata:
       annotations:
-        config-hash: {{ sha1sum (print (toYaml $.Values.scheduler.config) (dig "deployment" "spec" "strategy" "type" "" $.Values.scheduler) (dig "deployment" "spec" "replicas" 1 $.Values.scheduler)) }}
-        {{- with (dig "metadata" "annotations" (dict) $template) }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $podAnnotations | nindent 8 }}
       labels:
-        app: kube-scheduler
-        {{- with (dig "metadata" "labels" (dict) $template) }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml $podLabels | nindent 8 }}
     spec:
       containers:
         {{- toYaml $containers | nindent 8 }}
@@ -123,7 +148,7 @@ spec:
         {{- with $templateSpec.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $barfTemplate }}
+      {{- with $mergedPodSpec }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
 {{- end -}}

--- a/charts/k8s-control-plane/templates/scheduler/vpa.yaml
+++ b/charts/k8s-control-plane/templates/scheduler/vpa.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.scheduler.vpa.enabled -}}
+{{- if and $.Values.scheduler.enabled $.Values.scheduler.vpa.enabled -}}
 apiVersion: autoscaling.k8s.io/v1
 kind: VerticalPodAutoscaler
 metadata:

--- a/charts/k8s-control-plane/templates/validation.yaml
+++ b/charts/k8s-control-plane/templates/validation.yaml
@@ -1,0 +1,1 @@
+{{- include "k8s-control-plane.validate" . -}}

--- a/charts/k8s-control-plane/tests/run
+++ b/charts/k8s-control-plane/tests/run
@@ -3,6 +3,16 @@ set -euo pipefail
 
 test_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
 
-PYTHONDONTWRITEBYTECODE=1 python3 -B -m unittest discover \
+python_bin=${PYTHON:-python3}
+if ! "$python_bin" -c 'import yaml' >/dev/null 2>&1; then
+  if /usr/bin/python3 -c 'import yaml' >/dev/null 2>&1; then
+    python_bin=/usr/bin/python3
+  else
+    echo "PyYAML is required to run the chart tests" >&2
+    exit 1
+  fi
+fi
+
+PYTHONDONTWRITEBYTECODE=1 "$python_bin" -B -m unittest discover \
   --start-directory "$test_dir" \
   --pattern 'test_*.py'

--- a/charts/k8s-control-plane/tests/test_hosting_contract.py
+++ b/charts/k8s-control-plane/tests/test_hosting_contract.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import unittest
+
+import yaml
+
+from test_external_etcd_handoff import (
+    BASE_VALUES,
+    CLIENT_CERTIFICATE_REVISION,
+    SERVER_CA_REVISION,
+    helm_template,
+    object_named,
+    objects,
+)
+
+
+DIGESTS = {
+    "apiserver": "sha256:" + ("1a" * 32),
+    "controller-manager": "sha256:" + ("2b" * 32),
+    "kube-scheduler": "sha256:" + ("3c" * 32),
+}
+STABLE_LABELS = {
+    "app.kubernetes.io/name": "k8s-control-plane",
+    "app.kubernetes.io/instance": "child",
+}
+
+
+def legacy_values() -> dict:
+    values = copy.deepcopy(BASE_VALUES)
+    values["etcd"]["externalSecretRevisionsRequired"] = False
+    return values
+
+
+def hardened_values() -> dict:
+    values = copy.deepcopy(BASE_VALUES)
+    values["externalIP"] = None
+    values["externalHostname"] = "lab.example.test"
+    values["adminKubeconfig"] = {
+        "schedule": "@daily",
+        "concurrencyPolicy": "Forbid",
+    }
+    values["etcd"]["serverCATrustRevision"] = SERVER_CA_REVISION
+    values["etcd"]["clientCertificateRevision"] = CLIENT_CERTIFICATE_REVISION
+    values["parentWorkloads"] = {
+        "enabled": True,
+        "placement": {
+            "nodeSelector": {"node-role.samcday.com/fabric": ""},
+            "tolerations": [
+                {
+                    "key": "node-role.samcday.com/fabric",
+                    "operator": "Exists",
+                    "effect": "NoSchedule",
+                }
+            ],
+            "affinity": {
+                "nodeAffinity": {
+                    "preferredDuringSchedulingIgnoredDuringExecution": [
+                        {
+                            "weight": 1,
+                            "preference": {
+                                "matchExpressions": [
+                                    {
+                                        "key": "topology.kubernetes.io/zone",
+                                        "operator": "Exists",
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }
+            },
+        },
+        "podSecurityContext": {
+            "runAsNonRoot": True,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        },
+        "containerSecurityContext": {
+            "allowPrivilegeEscalation": False,
+            "readOnlyRootFilesystem": True,
+            "capabilities": {"drop": ["ALL"]},
+        },
+        "deployment": {
+            "priorityClassName": "system-cluster-critical",
+            "requiredPodAntiAffinityTopologyKey": "kubernetes.io/hostname",
+            "minReadySeconds": 10,
+            "terminationGracePeriodSeconds": 30,
+            "strategy": {
+                "type": "RollingUpdate",
+                "rollingUpdate": {"maxSurge": 0, "maxUnavailable": 1},
+            },
+            "pdb": {"enabled": True, "spec": {"minAvailable": 1}},
+        },
+    }
+    values["utilities"] = {
+        "image": "registry.k8s.io/kubectl:v1.35.3",
+        "resources": {"requests": {"cpu": "10m", "memory": "16Mi"}},
+        "writableTmp": True,
+    }
+    values["bootstrap"] = {"kubeadmAPIVersion": "kubeadm.k8s.io/v1beta4"}
+    values["konnectivity"] = {
+        "server": {
+            "clientIdentity": "dedicated",
+            "extraArgs": ["--v=2"],
+            "resources": {"requests": {"cpu": "10m"}},
+        }
+    }
+    values["monitoring"] = {"podMonitors": {"enabled": False}}
+    values["apiServer"] = {
+        "image": {"digest": DIGESTS["apiserver"]},
+        "resources": {"requests": {"cpu": "100m"}},
+        "securityContext": {"runAsUser": 65534},
+    }
+    values["controllerManager"] = {
+        "image": {"digest": DIGESTS["controller-manager"]},
+        "resources": {"requests": {"cpu": "50m"}},
+        "securityContext": {"runAsUser": 65534},
+    }
+    values["scheduler"] = {
+        "image": {"digest": DIGESTS["kube-scheduler"]},
+        "resources": {"requests": {"cpu": "50m"}},
+        "securityContext": {"runAsUser": 65534},
+        "vpa": {"enabled": False},
+    }
+    return values
+
+
+def workload_pods(rendered: list[dict]) -> dict[tuple[str, str], tuple[dict, dict]]:
+    result = {}
+    for document in rendered:
+        kind = document.get("kind")
+        name = document.get("metadata", {}).get("name")
+        if kind == "Deployment":
+            template = document["spec"]["template"]
+        elif kind == "Job":
+            template = document["spec"]["template"]
+        elif kind == "CronJob":
+            template = document["spec"]["jobTemplate"]["spec"]["template"]
+        else:
+            continue
+        result[(kind, name)] = (document, template)
+    return result
+
+
+def embedded_bootstrap(rendered: list[dict]) -> list[dict]:
+    job = object_named(rendered, "Job", "bootstrap")
+    command = job["spec"]["template"]["spec"]["containers"][0]["command"][-1]
+    start = command.index("apiVersion: v1")
+    end = command.index("\nHERE\n", start)
+    return [doc for doc in yaml.safe_load_all(command[start:end]) if isinstance(doc, dict)]
+
+
+class HostingContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        legacy = helm_template(legacy_values())
+        if legacy.returncode:
+            raise AssertionError(legacy.stderr)
+        cls.legacy = objects(legacy.stdout)
+
+        hardened = helm_template(hardened_values())
+        if hardened.returncode:
+            raise AssertionError(hardened.stderr)
+        cls.hardened = objects(hardened.stdout)
+
+    def test_legacy_defaults_remain_opt_in(self) -> None:
+        self.assertEqual(
+            {doc["metadata"]["name"] for doc in self.legacy if doc.get("kind") == "PodMonitor"},
+            {"apiserver", "controller-manager", "scheduler"},
+        )
+        self.assertFalse(any(doc.get("kind") == "PodDisruptionBudget" for doc in self.legacy))
+        self.assertFalse(
+            any(
+                doc.get("kind") == "Certificate"
+                and doc.get("metadata", {}).get("name") == "konnectivity-server"
+                for doc in self.legacy
+            )
+        )
+        binding = object_named(self.legacy, "ClusterRoleBinding", "system:konnectivity-server")
+        self.assertEqual(binding["roleRef"]["name"], "system:auth-delegator")
+        bootstrap = embedded_bootstrap(self.legacy)
+        config = yaml.safe_load(object_named(bootstrap, "ConfigMap", "kubeadm-config")["data"]["ClusterConfiguration"])
+        self.assertEqual(config["apiVersion"], "kubeadm.k8s.io/v1beta3")
+        apiserver = object_named(self.legacy, "Deployment", "apiserver")
+        self.assertNotIn("app.kubernetes.io/name", apiserver.get("metadata", {}).get("labels", {}))
+        self.assertNotIn("automountServiceAccountToken", apiserver["spec"]["template"]["spec"])
+
+    def test_hardened_contract_covers_every_parent_pod(self) -> None:
+        workloads = workload_pods(self.hardened)
+        expected_components = {
+            ("Deployment", "apiserver"): "apiserver",
+            ("Deployment", "controller-manager"): "controller-manager",
+            ("Deployment", "kube-scheduler"): "scheduler",
+            ("Job", "bootstrap"): "bootstrap",
+            ("Job", "ca-hash"): "ca-hash",
+            ("Job", "advertise-address"): "advertise-address",
+            ("Job", "admin-kubeconfig-generator"): "admin-kubeconfig-generator",
+            ("CronJob", "admin-kubeconfig-generator"): "admin-kubeconfig-generator",
+        }
+        self.assertEqual(set(workloads), set(expected_components))
+
+        tokenless = {
+            ("Deployment", "apiserver"),
+            ("Deployment", "controller-manager"),
+            ("Deployment", "kube-scheduler"),
+            ("Job", "bootstrap"),
+        }
+        for key, component in expected_components.items():
+            with self.subTest(workload=key):
+                document, template = workloads[key]
+                labels = {**STABLE_LABELS, "app.kubernetes.io/component": component}
+                self.assertEqual(labels.items() <= document["metadata"]["labels"].items(), True)
+                self.assertEqual(labels.items() <= template["metadata"]["labels"].items(), True)
+                if key[0] == "Job":
+                    self.assertEqual(
+                        document["metadata"]["annotations"][
+                            "helm.toolkit.fluxcd.io/driftDetection"
+                        ],
+                        "disabled",
+                    )
+                pod = template["spec"]
+                self.assertEqual(pod["nodeSelector"], {"node-role.samcday.com/fabric": ""})
+                self.assertEqual(pod["securityContext"]["runAsNonRoot"], True)
+                self.assertEqual(pod["securityContext"]["seccompProfile"], {"type": "RuntimeDefault"})
+                self.assertEqual(pod.get("automountServiceAccountToken", True), key not in tokenless)
+                volume_names = {volume["name"] for volume in pod.get("volumes", [])}
+                for container in pod["containers"]:
+                    security = container["securityContext"]
+                    self.assertFalse(security["allowPrivilegeEscalation"])
+                    self.assertTrue(security["readOnlyRootFilesystem"])
+                    self.assertEqual(security["capabilities"], {"drop": ["ALL"]})
+                    for mount in container.get("volumeMounts", []):
+                        self.assertIn(mount["name"], volume_names)
+
+                if key[0] == "Deployment":
+                    self.assertEqual(document["spec"]["minReadySeconds"], 10)
+                    self.assertEqual(
+                        document["spec"]["strategy"],
+                        {"type": "RollingUpdate", "rollingUpdate": {"maxSurge": 0, "maxUnavailable": 1}},
+                    )
+                    self.assertEqual(pod["priorityClassName"], "system-cluster-critical")
+                    self.assertEqual(pod["terminationGracePeriodSeconds"], 30)
+                    anti = pod["affinity"]["podAntiAffinity"]["requiredDuringSchedulingIgnoredDuringExecution"]
+                    self.assertEqual(anti[-1]["topologyKey"], "kubernetes.io/hostname")
+                    self.assertEqual(anti[-1]["labelSelector"]["matchLabels"], labels)
+
+    def test_hardened_images_resources_tmp_and_pdbs(self) -> None:
+        deployment_containers = {
+            name: object_named(self.hardened, "Deployment", name)["spec"]["template"]["spec"]["containers"]
+            for name in ("apiserver", "controller-manager", "kube-scheduler")
+        }
+        for deployment_name, container_name in (
+            ("apiserver", "apiserver"),
+            ("controller-manager", "controller-manager"),
+            ("kube-scheduler", "kube-scheduler"),
+        ):
+            container = next(c for c in deployment_containers[deployment_name] if c["name"] == container_name)
+            self.assertTrue(container["image"].endswith("@" + DIGESTS[deployment_name]))
+            self.assertEqual(container["securityContext"]["runAsUser"], 65534)
+            self.assertIn("cpu", container["resources"]["requests"])
+
+        proxy = next(c for c in deployment_containers["apiserver"] if c["name"] == "konnectivity-server")
+        self.assertIn("--v=2", proxy["args"])
+        self.assertEqual(proxy["resources"], {"requests": {"cpu": "10m"}})
+
+        for key, (_, template) in workload_pods(self.hardened).items():
+            if key[0] not in {"Job", "CronJob"}:
+                continue
+            pod = template["spec"]
+            container = pod["containers"][0]
+            self.assertEqual(container["image"], "registry.k8s.io/kubectl:v1.35.3")
+            self.assertEqual(container["resources"]["requests"]["cpu"], "10m")
+            self.assertIn({"name": "HOME", "value": "/tmp"}, container.get("env", []))
+            self.assertIn({"name": "tmp", "mountPath": "/tmp"}, container["volumeMounts"])
+            self.assertIn({"name": "tmp", "emptyDir": {}}, pod["volumes"])
+
+        pdbs = [doc for doc in self.hardened if doc.get("kind") == "PodDisruptionBudget"]
+        self.assertEqual({doc["metadata"]["name"] for doc in pdbs}, {"apiserver", "controller-manager", "kube-scheduler"})
+        for pdb in pdbs:
+            self.assertEqual(pdb["spec"]["minAvailable"], 1)
+            self.assertEqual(pdb["spec"]["selector"]["matchLabels"], pdb["metadata"]["labels"])
+        self.assertFalse(any(doc.get("kind") == "PodMonitor" for doc in self.hardened))
+
+        exporter = object_named(self.hardened, "CronJob", "admin-kubeconfig-generator")
+        self.assertEqual(exporter["spec"]["schedule"], "@daily")
+        self.assertEqual(exporter["spec"]["concurrencyPolicy"], "Forbid")
+
+    def test_dedicated_konnectivity_identity_is_child_scoped(self) -> None:
+        certificate = object_named(self.hardened, "Certificate", "konnectivity-server")
+        self.assertEqual(certificate["spec"]["commonName"], "system:konnectivity-server")
+        self.assertEqual(certificate["spec"]["issuerRef"], {"name": "ca", "kind": "Issuer"})
+        self.assertFalse(
+            any(
+                doc.get("kind") == "ClusterRoleBinding"
+                and doc.get("metadata", {}).get("name") == "system:konnectivity-server"
+                for doc in self.hardened
+            )
+        )
+        kubeconfig = yaml.safe_load(object_named(self.hardened, "ConfigMap", "konnectivity-server-kubeconfig")["data"]["kubeconfig"])
+        user = kubeconfig["users"][0]["user"]
+        self.assertEqual(user["client-certificate"], "/konnectivity-client/tls.crt")
+        self.assertEqual(user["client-key"], "/konnectivity-client/tls.key")
+
+        bootstrap = embedded_bootstrap(self.hardened)
+        binding = object_named(bootstrap, "ClusterRoleBinding", "system:konnectivity-server")
+        self.assertEqual(binding["roleRef"]["name"], "system:auth-delegator")
+        config = yaml.safe_load(object_named(bootstrap, "ConfigMap", "kubeadm-config")["data"]["ClusterConfiguration"])
+        self.assertEqual(config["apiVersion"], "kubeadm.k8s.io/v1beta4")
+
+    def test_scheduler_specific_overrides_remain_authoritative(self) -> None:
+        values = hardened_values()
+        values["scheduler"]["deployment"] = {
+            "labels": {"example.test/custom": "true"},
+            "spec": {
+                "minReadySeconds": 25,
+                "strategy": {"type": "Recreate"},
+                "template": {
+                    "spec": {
+                        "priorityClassName": "custom-priority",
+                        "nodeSelector": {"node-role.samcday.com/fabric": "custom"},
+                        "containers": [
+                            {
+                                "name": "kube-scheduler",
+                                "command": ["--v=4"],
+                                "securityContext": {"runAsUser": 1234},
+                            }
+                        ],
+                    }
+                },
+            },
+        }
+        result = helm_template(values)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        deployment = object_named(objects(result.stdout), "Deployment", "kube-scheduler")
+        self.assertEqual(deployment["spec"]["strategy"], {"type": "Recreate"})
+        self.assertEqual(deployment["spec"]["minReadySeconds"], 25)
+        pod = deployment["spec"]["template"]["spec"]
+        self.assertEqual(pod["priorityClassName"], "custom-priority")
+        self.assertEqual(pod["nodeSelector"], {"node-role.samcday.com/fabric": "custom"})
+        scheduler = pod["containers"][0]
+        self.assertIn("--v=4", scheduler["command"])
+        self.assertEqual(scheduler["securityContext"]["runAsUser"], 1234)
+
+    def test_disabling_scheduler_omits_all_scheduler_workloads(self) -> None:
+        values = legacy_values()
+        values["scheduler"] = {"enabled": False}
+        result = helm_template(values)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        rendered = objects(result.stdout)
+        self.assertFalse(
+            any(
+                doc.get("metadata", {}).get("name") in {
+                    "kube-scheduler",
+                    "scheduler",
+                }
+                and doc.get("kind") in {
+                    "Deployment",
+                    "PodMonitor",
+                    "VerticalPodAutoscaler",
+                }
+                for doc in rendered
+            )
+        )
+
+    def test_invalid_contract_values_are_rejected(self) -> None:
+        cases = []
+
+        invalid_digest = legacy_values()
+        invalid_digest["apiServer"] = {"image": {"digest": "sha256:NOT-A-DIGEST"}}
+        cases.append((invalid_digest, "apiServer.image.digest must be sha256:"))
+
+        invalid_kubeadm = legacy_values()
+        invalid_kubeadm["bootstrap"] = {"kubeadmAPIVersion": "kubeadm.k8s.io/v1beta2"}
+        cases.append((invalid_kubeadm, "bootstrap.kubeadmAPIVersion must be"))
+
+        invalid_identity = legacy_values()
+        invalid_identity["konnectivity"] = {"server": {"clientIdentity": "admin"}}
+        cases.append((invalid_identity, "konnectivity.server.clientIdentity must be"))
+
+        invalid_pdb = legacy_values()
+        invalid_pdb["parentWorkloads"] = {
+            "enabled": True,
+            "deployment": {"pdb": {"enabled": True, "spec": {}}},
+        }
+        cases.append((invalid_pdb, "pdb.spec must set exactly one"))
+
+        read_only = legacy_values()
+        read_only["parentWorkloads"] = {
+            "enabled": True,
+            "containerSecurityContext": {"readOnlyRootFilesystem": True},
+        }
+        cases.append((read_only, "utilities.writableTmp=true is required"))
+
+        too_many_cidrs = legacy_values()
+        too_many_cidrs["serviceCIDRs"] = ["10.0.0.0/16", "fd00::/108", "10.1.0.0/16"]
+        cases.append((too_many_cidrs, "too many serviceCIDRs"))
+
+        for values, message in cases:
+            with self.subTest(message=message):
+                result = helm_template(values)
+                self.assertNotEqual(result.returncode, 0, result.stdout)
+                self.assertIn(message, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/charts/k8s-control-plane/values.yaml
+++ b/charts/k8s-control-plane/values.yaml
@@ -1,10 +1,13 @@
 apiServer:
   extraArgs: []
   image:
+    digest: ""
     repository: registry.k8s.io/kube-apiserver
     pullPolicy: IfNotPresent
     tag: "v{{ $.Values.version }}"
   replicas: 2
+  resources: {}
+  securityContext: {}
   service:
     annotations:
     labels:
@@ -15,22 +18,38 @@ apiServer:
   vpa:
     enabled: true
 
+adminKubeconfig:
+  # Refresh flattened kubeconfigs after cert-manager rotates their source
+  # certificates. Existing releases retain the historical weekly cadence.
+  schedule: "@weekly"
+  concurrencyPolicy: ""
+
 bootstrapTokens:
   # - token: abcdef.0123456789abcdef
   # - id: abcdef
   #   extraGroups: [system:bootstrappers:kubeadm:default-node-token]
   #   secret: 0123456789abcdef
 
+bootstrap:
+  # kubeadm 1.31 and newer write v1beta4; keep v1beta3 as the legacy default.
+  kubeadmAPIVersion: kubeadm.k8s.io/v1beta3
+
 clusterDomain: cluster.local
+
+clusterCIDRs: []
+clusterDNS: []
 
 clusterName: ~ # required
 
 controllerManager:
   image:
+    digest: ""
     repository: registry.k8s.io/kube-controller-manager
     pullPolicy: IfNotPresent
     tag: "v{{ $.Values.version }}"
   replicas: 2
+  resources: {}
+  securityContext: {}
   vpa:
     enabled: true
 
@@ -75,9 +94,40 @@ konnectivity:
     replicas: 2
   port: 8091
   server:
+    # dedicated uses a child-CA identity scoped to TokenReview delegation.
+    # legacyAdmin preserves the historical system:masters client identity.
+    clientIdentity: legacyAdmin
+    extraArgs: []
     image: registry.k8s.io/kas-network-proxy/proxy-server:v0.33.0
+    resources: {}
+
+monitoring:
+  podMonitors:
+    enabled: true
 
 parentClusterDomain: cluster.local
+
+serviceIP: null
+
+# Opt-in contract for workloads that run in the parent/hosting cluster. Keeping
+# this disabled preserves the historical manifests for existing releases.
+parentWorkloads:
+  enabled: false
+  placement:
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+  podSecurityContext: {}
+  containerSecurityContext: {}
+  deployment:
+    priorityClassName: ""
+    requiredPodAntiAffinityTopologyKey: ""
+    minReadySeconds: 0
+    terminationGracePeriodSeconds: null
+    strategy: {}
+    pdb:
+      enabled: false
+      spec: {}
 
 scheduler:
   enabled: true
@@ -109,11 +159,21 @@ scheduler:
       #     volumes:
       #       - name: extra
   image:
+    digest: ""
     repository: registry.k8s.io/kube-scheduler
     pullPolicy: IfNotPresent
     tag: "v{{ $.Values.version }}"
+  resources: {}
+  securityContext: {}
   vpa:
     enabled: true
+
+utilities:
+  image: bitnamilegacy/kubectl:1.33.4
+  resources: {}
+  # Mount an emptyDir at /tmp and set HOME there. Required when the common
+  # container security context makes the root filesystem read-only.
+  writableTmp: false
 
 # Additional client-certificate identities for child-cluster access.
 #

--- a/docs/network-cidrs.md
+++ b/docs/network-cidrs.md
@@ -20,6 +20,7 @@ take precedence over convenient CIDR shorthand.
 | `cloud-cluster` | Hetzner `172.29.0.0/16` | `172.28.0.0/16` | `172.27.0.0/16` | Headscale address expected at `100.64.0.3` |
 | `ilumbaclusta` | `10.0.3.0/24` | `172.28.0.0/16` | `172.27.0.0/16` | dynamically allocated from the hub BGP service interval |
 | `edge-au-east` | provider-assigned; no CIDR in this repo | `172.24.0.0/16` | `172.23.0.0/16` | parent Service `172.27.23.43`; Headscale address expected at `100.64.0.64` |
+| `lab` | no workers allocated | `172.26.0.0/16` | `172.25.0.0/16` | Fabric parent Service `172.21.0.25`; `lab-apiserver.tailnet.hub.samcday.com`, with its IPv4 assigned dynamically from Headscale |
 
 The hub declarations come from the [router LAN and node
 leases](../hub/router/files/etc/uci-defaults/system), [K3s
@@ -95,12 +96,13 @@ and no non-host `AllowedIPs` accepted from its peers. The check did not inspect
 kernel routes inside Kubernetes nodes, a live OpenWrt router, Headscale's
 server-side approvals, the home gateway, or the Superloop path.
 
-No `advertise-routes` or equivalent subnet-route declaration exists in the
-repository. The common OpenWrt overlay permits forwarding between Tailscale
-and LAN zones but logs in without advertising a prefix. No subnet route was
-accepted by the live `sam-desktop` client; Headscale's server-side approvals
-and other clients remain unverified. The fabric router overlay explicitly
-removes Tailscale.
+The common OpenWrt overlay permits forwarding between Tailscale and LAN zones
+but logs in without advertising a prefix, and the physical Fabric router image
+explicitly removes Tailscale. Fabric instead runs two Kubernetes-hosted
+userspace subnet routers, one on each service node, declaring
+`10.66.0.0/24,10.66.1.0/24`; Headscale owns approval and ACL enforcement for
+those routes. The earlier `sam-desktop` spot-check below predates that
+declaration and is retained only as dated evidence, not current route state.
 
 ## Allocated fabric space
 
@@ -117,7 +119,7 @@ advertisement or cross-cluster transport.
 | Purpose | Range or address | Status |
 | --- | --- | --- |
 | Consensus and provisioning LAN | `10.66.0.0/24` | Live; no Git, live hub/cloud, or operator-route collision found; intentionally not advertised. |
-| Service-node LAN | `10.66.1.0/24` | Allocated for persistent fabric platform agents; staged for temporary routed use on the shared physical L2, pending live qualification. |
+| Service-node LAN | `10.66.1.0/24` | Live for persistent Fabric platform agents on the accepted temporary shared physical L2. |
 | Fabric Pod network | `172.22.0.0/16` | Live in K3s configuration; no Git, live hub/cloud, or operator-route collision found. |
 | Fabric Service network | `172.21.0.0/16` | Live in K3s configuration; no Git, live hub/cloud, or operator-route collision found. |
 | Router and offline asset server | `10.66.0.1` | Live router address. |
@@ -132,19 +134,23 @@ advertisement or cross-cluster transport.
 | Fabric API VIP | `10.66.0.254` | Live kube-vip API endpoint. |
 | Service-plane router | `10.66.1.1` | Staged as a second address on the router's sole fabric link; pending live qualification. |
 | Service-plane low-address holdback | `10.66.1.2-10.66.1.9` | Reserved; no DHCP allocation. |
-| Persistent platform agents | `10.66.1.10-10.66.1.11` | Allocated to `fabric-az1-svc1` and `fabric-az1-svc2`; not live yet. |
+| Persistent platform agents | `10.66.1.10-10.66.1.11` | Live on `fabric-az1-svc1` and `fabric-az1-svc2`. |
 | Service-plane holdback | `10.66.1.12-10.66.1.99` | Reserved for future reviewed service nodes; not a child-cluster pool. |
 | Service-plane candidate holdback | `10.66.1.100` | Held but unused during flat-L2 induction. Bootie discovery stays on `10.66.0.100`; the router grants `.1.100` no service and tests it as an unauthorized source. |
 | Remaining service-plane holdback | `10.66.1.101-10.66.1.254` | Unallocated; no DHCP allocation or publishing pool. |
+| Lab parent apiserver Service | `172.21.0.25` | Reserved inside the Fabric Service CIDR for the hosted `lab` apiserver. |
+| Lab child Kubernetes Service | `172.25.0.1` | First address in the lab Service CIDR. |
+| Lab child DNS Service | `172.25.0.10` | Reserved for future child CoreDNS; no child DNS workload is installed yet. |
 
 Evidence is in the [fabric plan](plans/fabric-cluster.md), [router
 configuration](../fabric/router/files/etc/uci-defaults/10-system), [node
 profiles](../fabric/butane/fabric-az1-cp1.yaml), and [K3s
 configuration](../fabric/butane/control-plane.yaml). The temporary flat-L2
-realization permits only the two named, physically trusted platform agents
-after router and root-host policy tests. It is not sufficient for child etcd
-credentials or tenant workloads. No child-cluster allocation block or
-externally published fabric load-balancer pool has been allocated yet.
+realization permits only the two named, physically trusted platform agents and
+the reviewed infrastructure-owned `lab` control plane after router, host,
+mTLS, prefix-RBAC, and NetworkPolicy qualification. It remains insufficient for
+independently administered or untrusted tenants. No externally published
+Fabric load-balancer pool has been allocated.
 
 ## Confirmed overlaps and sharp edges
 
@@ -159,7 +165,7 @@ externally published fabric load-balancer pool has been allocated yet.
   cloud Pod and node `/16`s. This is not an independent third workload range.
 - **Expected shared LAN:** the hub L2 pool is inside `10.0.1.0/24`. Its exact
   interval does not overlap the current static router, node, or API addresses.
-- **No repository collision:** the three proposed fabric ranges are disjoint
+- **No repository collision:** the Fabric and lab ranges are disjoint
   from every current Pod, Service, physical LAN, and publishing range listed
   above. This says nothing about networks absent from Git.
 - **External collision risk:** Headscale's `100.64.0.0/10` is carrier-grade NAT
@@ -181,8 +187,10 @@ externally published fabric load-balancer pool has been allocated yet.
   additional addresses on those LANs.
 - The allocated fabric service subnet still needs its permanent managed-switch
   VLAN realization. Its temporary same-wire realization is deliberately not
-  an anti-spoofing boundary. Future worker subnets, child Pod/Service blocks,
-  and published VIP pools require new entries before deployment.
+  an anti-spoofing boundary and is an accepted risk only for the trusted
+  platform and `lab` control plane. Future worker subnets, further child
+  Pod/Service blocks, and published VIP pools require new entries before
+  deployment.
 - `10.244.0.0/16`, `10.96.0.0/12`, and `10.0.0.10` occur only in chart defaults
   or a Helm-render example; they are not repository allocations.
 - `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`, `0.0.0.0/0`, and `::/0`

--- a/fabric/README.md
+++ b/fabric/README.md
@@ -13,9 +13,12 @@ retaining their final addresses. This is routing and policy separation, not a
 security boundary: only the two trusted service nodes and reviewed foundation
 workloads may use it. A narrow exception admits the Fabric-hosted etcdetcetc
 controller and its dedicated smoke identity to TCP/2379 so the shared-etcd
-tenancy foundation can be proven. It does not admit a child control plane,
-general tenant workloads, KubeVirt, or worker induction; those remain gated on
-the managed-switch VLAN boundary.
+tenancy foundation can be proven. The infrastructure-owned `lab` child control
+plane is a second reviewed exception: it uses mTLS-scoped etcd credentials and
+fail-closed NetworkPolicies while explicitly accepting the remaining same-wire
+spoofing risk. General tenant workloads, KubeVirt, and worker induction remain
+excluded. A managed-switch VLAN is desirable defense in depth, but is not a
+prerequisite for this trusted hosted control plane.
 Future Bootie provisioning remains worker-only and attended.
 
 The design and induction gates live in

--- a/fabric/cluster/README.md
+++ b/fabric/cluster/README.md
@@ -18,10 +18,12 @@ share one physical L2 across daisy-chained unmanaged switches. IP allow-lists
 cannot stop source spoofing on that wire. Until a managed switch enforces the
 declared VLANs, admit only these physically trusted machines and the reviewed
 Flux, CoreDNS, metrics-server, cert-manager, and etcdetcetc foundation needed
-to finish the platform. The dedicated etcdetcetc controller identity and one
-retained-data smoke tenant are the sole temporary etcd-client exception. Do
-not place a child control plane, other child etcd credentials, KubeVirt,
-tenant VMs, LLM jobs, or other untrusted workloads there.
+to finish the platform. The dedicated etcdetcetc controller identity, retained
+smoke tenant, and infrastructure-owned `lab` control plane are reviewed
+exceptions. The lab apiserver has a prefix-scoped mTLS identity and explicit
+NetworkPolicies, but those controls do not turn the shared wire into an
+anti-spoofing boundary. Do not place independently administered child control
+planes, KubeVirt, tenant VMs, LLM jobs, or other untrusted workloads there.
 
 K3s keeps only Flannel and kube-proxy from its normal base. Its packaged
 CoreDNS and metrics-server Addons remain disabled: this tree owns pinned,
@@ -37,10 +39,11 @@ required by K3s startup. Successful negative
 authorization tests, a controlled K3s restart/rejoin and token-rotation test,
 negative tests of the installed host guard, and a routed service-policy test
 are hard gates before the first service node joins. Physical VLAN isolation
-and its anti-spoofing tests remain hard gates before a child control-plane
-identity or general tenant workload is created. The etcdetcetc foundation
-exception requires separate positive and negative source, port, mTLS, and
-prefix-RBAC qualification before its smoke identity is accepted.
+and its anti-spoofing tests remain hard gates before independently administered
+or untrusted workloads are admitted, but not before the trusted Fabric-hosted
+`lab` control plane. The etcdetcetc foundation and lab exceptions require
+separate positive and negative source, port, mTLS, and prefix-RBAC
+qualification before their identities are accepted.
 
 All control planes admitted to the physical Fabric etcd are consequently one
 trusted availability domain. EtcdTenant prefixes protect key confidentiality

--- a/fabric/cluster/etcdetcetc-controller/release.yaml
+++ b/fabric/cluster/etcdetcetc-controller/release.yaml
@@ -42,6 +42,7 @@ spec:
     allowedNamespaces:
       - etcdetcetc
       - etcdetcetc-smoke
+      - lab
     image:
       repository: ghcr.io/samcday/infra-etcdetcetc
       tag: "2026072506.00000000030147245918"
@@ -49,6 +50,7 @@ spec:
       pullPolicy: IfNotPresent
     managedNamespaces:
       - etcdetcetc-smoke
+      - lab
     legacyClusterWideCoreWatches: false
     replicaCount: 2
     nodeSelector:

--- a/fabric/cluster/etcdetcetc/README.md
+++ b/fabric/cluster/etcdetcetc/README.md
@@ -404,16 +404,15 @@ objects at another physical cluster.
 
 ## First child control-plane handoff
 
-This section defines the future handoff; it is not permission to create a child
-on the temporary flat L2. The managed-switch VLAN and anti-spoof gates in
-`fabric/cluster/README.md` remain mandatory. Before the first child, extend
-`charts/k8s-control-plane` with one exact svc1/svc2 placement contract shared
-by every apiserver/controller-manager/scheduler Deployment and every bootstrap
-Job/CronJob, plus hard hostname spreading. Fabric also needs PodMonitor output
-disabled and all three VPAs disabled until those CRDs/controllers are installed,
-then disjoint child CIDRs and an API publishing address/mechanism. The current
-chart's generated TLS-etcd handoff renders correctly, but those parent-cluster
-scheduling and API-exposure prerequisites are intentionally still absent.
+The first handoff is the infrastructure-owned `lab` control plane. Its
+deployment explicitly accepts the temporary flat-L2 spoofing risk documented
+in `fabric/cluster/README.md`; the managed-switch VLAN is defense in depth, not
+a gate for this trusted tenant. The chart must use one exact svc1/svc2
+placement contract for every apiserver/controller-manager/scheduler Deployment
+and bootstrap Job/CronJob, hard hostname anti-affinity, Restricted Pod Security,
+disabled PodMonitors/VPAs, disjoint child CIDRs, and the dedicated Tailnet API
+publisher. This exception does not authorize an independently administered or
+untrusted tenant on the shared wire.
 
 Create the child namespace through Flux before its HelmRelease, and label it
 for the fail-closed control-plane PKI policies:
@@ -422,7 +421,7 @@ for the fail-closed control-plane PKI policies:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: svc1-child
+  name: lab
   labels:
     fabric.samcday.com/k8s-control-plane: "true"
 ```
@@ -446,11 +445,15 @@ spec:
     - kind: ConfigMap
       name: apiserver-etcd
       valuesKey: values.yaml
+    - kind: ConfigMap
+      name: lab-control-plane-endpoint
+      valuesKey: values.yaml
 ```
 
 Do not use individual `targetPath` injections for the comma-separated endpoint
-field. The generated complete values document avoids Helm `--set` parsing and
-is labelled `reconcile.fluxcd.io/watch: Enabled`. A verified client-leaf renewal
+field. The generated etcd document and atomically published Tailnet endpoint
+document avoid Helm `--set` parsing and are labelled
+`reconcile.fluxcd.io/watch: Enabled`. A verified client-leaf renewal
 alters `etcd.clientCertificateRevision`; kube-apiserver does not reliably
 reload `--etcd-certfile`/`--etcd-keyfile` in place, so that public-certificate
 revision rolls its Pod template. It hashes only the published `tls.crt`, never

--- a/fabric/cluster/etcdetcetc/runtime/cluster.yaml
+++ b/fabric/cluster/etcdetcetc/runtime/cluster.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   allowedNamespaces:
     - etcdetcetc-smoke
+    - lab
   authSecretRef:
     name: fabric-etcdetcetc-admin
   endpoints:

--- a/fabric/cluster/flux-system/children.yaml
+++ b/fabric/cluster/flux-system/children.yaml
@@ -193,3 +193,82 @@ spec:
     namespace: flux-system
   timeout: 5m
   wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: fabric-lab-foundation
+  namespace: flux-system
+spec:
+  # Activation is intentionally attended: (1) reconcile the Hub Terraform
+  # auth key, (2) run scripts/handoff-lab-apiserver-auth, (3) add the generated
+  # SOPS Secret to lab/foundation/kustomization.yaml, then (4) unsuspend only
+  # this foundation and wait for the tenant, Tailnet proxy, and endpoint
+  # publisher to become Ready.
+  suspend: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: age-key
+  dependsOn:
+    - name: fabric-platform
+    - name: fabric-tailnet
+    - name: fabric-etcdetcetc-runtime
+  healthCheckExprs:
+    - apiVersion: etcdetcetc.samcday.com/v1alpha1
+      kind: EtcdTenant
+      current: >-
+        has(status.conditions) &&
+        status.conditions.exists(c,
+          c.type == 'Ready' && c.status == 'True' &&
+          has(c.observedGeneration) &&
+          c.observedGeneration == metadata.generation)
+      failed: "false"
+  healthChecks:
+    - apiVersion: etcdetcetc.samcday.com/v1alpha1
+      kind: EtcdTenant
+      name: apiserver
+      namespace: lab
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: lab-apiserver-tailnet
+      namespace: lab
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: lab-apiserver-endpoint-publisher
+      namespace: lab
+  interval: 10m
+  path: ./fabric/cluster/lab/foundation
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+    namespace: flux-system
+  timeout: 15m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: fabric-lab-control-plane
+  namespace: flux-system
+spec:
+  # Unsuspend only after fabric-lab-foundation is Ready. In particular, the
+  # generated apiserver-etcd and lab-control-plane-endpoint values documents
+  # must exist before Helm is allowed to render the control plane.
+  suspend: true
+  dependsOn:
+    - name: fabric-lab-foundation
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: control-plane
+      namespace: lab
+  interval: 10m
+  path: ./fabric/cluster/lab/control-plane
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+    namespace: flux-system
+  timeout: 15m
+  wait: true

--- a/fabric/cluster/foundation/coredns.yaml
+++ b/fabric/cluster/foundation/coredns.yaml
@@ -100,6 +100,7 @@ spec:
   revisionHistoryLimit: 0
   strategy:
     rollingUpdate:
+      maxSurge: 0
       maxUnavailable: 1
     type: RollingUpdate
   selector:
@@ -110,6 +111,13 @@ spec:
       labels:
         k8s-app: kube-dns
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+              topologyKey: kubernetes.io/hostname
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       nodeSelector:

--- a/fabric/cluster/lab/control-plane/control-plane-values.yaml
+++ b/fabric/cluster/lab/control-plane/control-plane-values.yaml
@@ -1,0 +1,158 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: control-plane-values
+  namespace: lab
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
+data:
+  values.yaml: |
+    adminKubeconfig:
+      schedule: "@daily"
+      concurrencyPolicy: Forbid
+    apiServer:
+      image:
+        digest: sha256:b4bc06c81fd76f81174e6c19ddacf477acdf1583e7a5846ebbd513493aef6e43
+      replicas: 2
+      resources:
+        requests:
+          cpu: 150m
+          memory: 384Mi
+        limits:
+          memory: 1Gi
+      securityContext:
+        capabilities:
+          add:
+            - NET_BIND_SERVICE
+          drop:
+            - ALL
+      service:
+        spec:
+          clusterIP: 172.21.0.25
+          type: ClusterIP
+      vpa:
+        enabled: false
+    bootstrap:
+      kubeadmAPIVersion: kubeadm.k8s.io/v1beta4
+    bootstrapTokens: []
+    clusterCIDRs:
+      - 172.26.0.0/16
+    clusterDNS:
+      - 172.25.0.10
+    clusterDomain: cluster.local
+    clusterName: lab
+    controllerManager:
+      image:
+        digest: sha256:ed56454bf514916079a227f5765b64524fde52106dfcc52978b28634765b78b8
+      replicas: 2
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+      vpa:
+        enabled: false
+    konnectivity:
+      enabled: true
+      agent:
+        image: registry.k8s.io/kas-network-proxy/proxy-agent:v0.36.0@sha256:5f534dd5f02a751bfc6cb9d2d2342c622d37ba9e8c6851768769ed8a9081b915
+        replicas: 2
+      port: 8091
+      server:
+        clientIdentity: dedicated
+        extraArgs:
+          - --graceful-shutdown-timeout=20s
+        image: registry.k8s.io/kas-network-proxy/proxy-server:v0.36.0@sha256:61b6bfed89291cbee0dd0d5f9bb4982c6989059b15398690cd89e830ac29f1b7
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 128Mi
+    monitoring:
+      podMonitors:
+        enabled: false
+    parentClusterDomain: cluster.fabric.internal
+    parentWorkloads:
+      enabled: true
+      placement:
+        nodeSelector:
+          fabric.samcday.com/platform: "true"
+          kubernetes.io/os: linux
+        tolerations:
+          - effect: NoSchedule
+            key: fabric.samcday.com/platform
+            operator: Equal
+            value: "true"
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchFields:
+                    - key: metadata.name
+                      operator: In
+                      values:
+                        - fabric-az1-svc1
+                        - fabric-az1-svc2
+      podSecurityContext:
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsGroup: 65532
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      deployment:
+        priorityClassName: system-cluster-critical
+        requiredPodAntiAffinityTopologyKey: kubernetes.io/hostname
+        minReadySeconds: 10
+        terminationGracePeriodSeconds: 30
+        strategy:
+          type: RollingUpdate
+          rollingUpdate:
+            maxSurge: 0
+            maxUnavailable: 1
+        pdb:
+          enabled: true
+          spec:
+            minAvailable: 1
+    scheduler:
+      deployment:
+        spec:
+          replicas: 2
+      image:
+        digest: sha256:128fc07d278d64c4f2cce416ed0a9f37b23a30cdde6f97873d18c9c78e259df4
+      resources:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          memory: 256Mi
+      vpa:
+        enabled: false
+    serviceCIDRs:
+      - 172.25.0.0/16
+    serviceIP: 172.25.0.1
+    users: []
+    utilities:
+      image: docker.io/bitnami/kubectl:latest@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d
+      resources:
+        requests:
+          cpu: 10m
+          memory: 32Mi
+        limits:
+          memory: 128Mi
+      writableTmp: true
+    version: 1.36.3

--- a/fabric/cluster/lab/control-plane/kustomization.yaml
+++ b/fabric/cluster/lab/control-plane/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - control-plane-values.yaml
+  - release.yaml

--- a/fabric/cluster/lab/control-plane/release.yaml
+++ b/fabric/cluster/lab/control-plane/release.yaml
@@ -1,0 +1,38 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: control-plane
+  namespace: lab
+spec:
+  chart:
+    spec:
+      chart: charts/k8s-control-plane
+      reconcileStrategy: Revision
+      sourceRef:
+        kind: GitRepository
+        name: infra
+        namespace: flux-system
+  driftDetection:
+    mode: enabled
+  install:
+    remediation:
+      retries: 3
+  interval: 1h
+  timeout: 10m
+  upgrade:
+    cleanupOnFail: true
+    # Jobs in this chart have ttlSecondsAfterFinished and get GC'd between
+    # upgrades; force recreates missing resources instead of patching them.
+    force: true
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: ConfigMap
+      name: control-plane-values
+      valuesKey: values.yaml
+    - kind: ConfigMap
+      name: apiserver-etcd
+      valuesKey: values.yaml
+    - kind: ConfigMap
+      name: lab-control-plane-endpoint
+      valuesKey: values.yaml

--- a/fabric/cluster/lab/foundation/README.md
+++ b/fabric/cluster/lab/foundation/README.md
@@ -1,0 +1,24 @@
+# Lab control-plane foundation
+
+This directory prepares the Fabric-hosted `lab` control plane without creating
+workers or child-cluster add-ons. It provisions the etcdetcetc tenant, the
+Tailnet TCP proxy, and an endpoint publisher that writes the proxy's dynamically
+assigned CGNAT IPv4 into `lab-control-plane-endpoint`.
+
+Both `fabric-lab-foundation` and `fabric-lab-control-plane` are committed
+suspended. Activation is deliberately attended:
+
+1. Reconcile the Hub Headscale Terraform until its
+   `headscale/lab-apiserver-ts-auth` Secret exists.
+2. Run `scripts/handoff-lab-apiserver-auth` from the repository root.
+3. Add `apiserver-ts-auth.sops.yaml` to this directory's `kustomization.yaml`.
+   Never add a plaintext or placeholder auth key.
+4. Unsuspend `fabric-lab-foundation` and wait for its EtcdTenant and both
+   Deployments to report Ready. The publisher fails closed unless Headscale
+   reports exactly `lab-apiserver.tailnet.hub.samcday.com` and an IPv4 inside
+   `100.64.0.0/10`.
+5. Only then unsuspend `fabric-lab-control-plane`.
+
+The empty Tailnet state Secret is declarative. The Tailnet pod alone may update
+it; the endpoint publisher may only read it and patch the pre-created endpoint
+ConfigMap with server-side apply.

--- a/fabric/cluster/lab/foundation/endpoint-publisher.yaml
+++ b/fabric/cluster/lab/foundation/endpoint-publisher.yaml
@@ -1,0 +1,181 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lab-apiserver-endpoint-publisher
+  namespace: lab
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lab-apiserver-endpoint-publisher
+  namespace: lab
+rules:
+  - apiGroups: [""]
+    resourceNames: [lab-apiserver-ts-state]
+    resources: [secrets]
+    verbs: [get]
+  - apiGroups: [""]
+    resourceNames: [lab-control-plane-endpoint]
+    resources: [configmaps]
+    verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lab-apiserver-endpoint-publisher
+  namespace: lab
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lab-apiserver-endpoint-publisher
+subjects:
+  - kind: ServiceAccount
+    name: lab-apiserver-endpoint-publisher
+    namespace: lab
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lab-apiserver-endpoint-publisher
+  namespace: lab
+  labels:
+    app.kubernetes.io/component: endpoint-publisher
+    app.kubernetes.io/instance: lab
+    app.kubernetes.io/name: lab-apiserver-endpoint-publisher
+    app.kubernetes.io/part-of: lab-control-plane
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: lab-apiserver-endpoint-publisher
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: endpoint-publisher
+        app.kubernetes.io/instance: lab
+        app.kubernetes.io/name: lab-apiserver-endpoint-publisher
+        app.kubernetes.io/part-of: lab-control-plane
+    spec:
+      automountServiceAccountToken: true
+      enableServiceLinks: false
+      serviceAccountName: lab-apiserver-endpoint-publisher
+      terminationGracePeriodSeconds: 30
+      nodeSelector:
+        fabric.samcday.com/platform: "true"
+        kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchFields:
+                  - key: metadata.name
+                    operator: In
+                    values:
+                      - fabric-az1-svc1
+                      - fabric-az1-svc2
+      tolerations:
+        - effect: NoSchedule
+          key: fabric.samcday.com/platform
+          operator: Equal
+          value: "true"
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: OnRootMismatch
+        runAsGroup: 1001
+        runAsNonRoot: true
+        runAsUser: 1001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: publisher
+          image: docker.io/bitnami/kubectl:latest@sha256:95de17e6eb92da83a58c90a9df0c4cede634f898d2e6b92ea04f4a6ee6ace08d
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/sh
+            - -ec
+          args:
+            - |
+              set -eu
+              expected_fqdn=lab-apiserver.tailnet.hub.samcday.com
+
+              while true; do
+                rm -f /tmp/published
+
+                encoded_fqdn=$(kubectl -n lab get secret lab-apiserver-ts-state \
+                  -o jsonpath='{.data.device_fqdn}' 2>/dev/null || true)
+                encoded_ips=$(kubectl -n lab get secret lab-apiserver-ts-state \
+                  -o jsonpath='{.data.device_ips}' 2>/dev/null || true)
+                fqdn=$(printf '%s' "$encoded_fqdn" | base64 -d 2>/dev/null || true)
+                fqdn=$(printf '%s' "$fqdn" | sed 's/\.$//')
+                ips=$(printf '%s' "$encoded_ips" | base64 -d 2>/dev/null || true)
+
+                ipv4=$(printf '%s\n' "$ips" | tr -d '[]" ' | tr ',' '\n' | \
+                  awk -F. '
+                    /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/ && NF == 4 {
+                      if ($1 == 100 && $2 >= 64 && $2 <= 127 &&
+                          $3 >= 0 && $3 <= 255 && $4 >= 0 && $4 <= 255) {
+                        print $0
+                        exit
+                      }
+                    }
+                  ')
+
+                if [ "$fqdn" = "$expected_fqdn" ] && [ -n "$ipv4" ]; then
+                  expected=$(printf 'externalHostname: "%s"\nexternalIP: "%s"\n' \
+                    "$fqdn" "$ipv4")
+                  current=$(kubectl -n lab get configmap lab-control-plane-endpoint \
+                    -o jsonpath='{.data.values\.yaml}' 2>/dev/null || true)
+                  if [ "$current" != "$expected" ]; then
+                    printf '%s\n' \
+                      'apiVersion: v1' \
+                      'kind: ConfigMap' \
+                      'metadata:' \
+                      '  name: lab-control-plane-endpoint' \
+                      '  namespace: lab' \
+                      'data:' \
+                      '  values.yaml: |' \
+                      "    externalHostname: \"$fqdn\"" \
+                      "    externalIP: \"$ipv4\"" | \
+                      kubectl apply --server-side \
+                        --field-manager=lab-apiserver-endpoint-publisher -f -
+                    current=$(kubectl -n lab get configmap lab-control-plane-endpoint \
+                      -o jsonpath='{.data.values\.yaml}' 2>/dev/null || true)
+                  fi
+                  if [ "$current" = "$expected" ]; then
+                    printf '%s\n' "$ipv4" >/tmp/published
+                  fi
+                fi
+
+                sleep 10
+              done
+          env:
+            - name: HOME
+              value: /tmp
+          readinessProbe:
+            exec:
+              command: [/bin/sh, -ec, test -s /tmp/published]
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+      volumes:
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+          name: tmp

--- a/fabric/cluster/lab/foundation/endpoint.yaml
+++ b/fabric/cluster/lab/foundation/endpoint.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lab-control-plane-endpoint
+  namespace: lab
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: Merge
+  labels:
+    reconcile.fluxcd.io/watch: Enabled
+
+# The endpoint publisher owns data.values.yaml through server-side apply.
+# Leaving data absent keeps Flux from claiming or clearing that field.

--- a/fabric/cluster/lab/foundation/etcd-tenant.yaml
+++ b/fabric/cluster/lab/foundation/etcd-tenant.yaml
@@ -1,0 +1,13 @@
+apiVersion: etcdetcetc.samcday.com/v1alpha1
+kind: EtcdTenant
+metadata:
+  name: apiserver
+  namespace: lab
+  annotations:
+    etcdetcetc.samcday.com/shared-availability-risk: accepted-v1
+spec:
+  clusterRef:
+    name: fabric-etcd
+    namespace: etcdetcetc
+  credentialMode: TLS
+  secretName: apiserver-etcd-client

--- a/fabric/cluster/lab/foundation/kustomization.yaml
+++ b/fabric/cluster/lab/foundation/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - etcd-tenant.yaml
+  - endpoint.yaml
+  - tailnet.yaml
+  - endpoint-publisher.yaml
+  - network-policies.yaml
+
+# Activation gate: after scripts/handoff-lab-apiserver-auth creates the
+# encrypted file, add this resource before unsuspending fabric-lab-foundation:
+#   - apiserver-ts-auth.sops.yaml

--- a/fabric/cluster/lab/foundation/network-policies.yaml
+++ b/fabric/cluster/lab/foundation/network-policies.yaml
@@ -1,0 +1,288 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: lab
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns
+  namespace: lab
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 172.21.0.10/32
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+---
+# Only the two foundation agents and chart utility Jobs need the hosting
+# cluster's API. The long-lived child control-plane processes use the lab API.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-foundation-fabric-api-egress
+  namespace: lab
+spec:
+  podSelector:
+    matchExpressions:
+      - key: app.kubernetes.io/name
+        operator: In
+        values:
+          - lab-apiserver-tailnet
+          - lab-apiserver-endpoint-publisher
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 172.21.0.1/32
+      ports:
+        - port: 443
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 10.66.0.10/32
+        - ipBlock:
+            cidr: 10.66.0.11/32
+        - ipBlock:
+            cidr: 10.66.0.12/32
+        - ipBlock:
+            cidr: 10.66.0.254/32
+      ports:
+        - port: 6443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-control-plane-utilities-fabric-api-egress
+  namespace: lab
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-control-plane
+      app.kubernetes.io/instance: control-plane
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - ca-hash
+          - advertise-address
+          - admin-kubeconfig-generator
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 172.21.0.1/32
+      ports:
+        - port: 443
+          protocol: TCP
+    - to:
+        - ipBlock:
+            cidr: 10.66.0.10/32
+        - ipBlock:
+            cidr: 10.66.0.11/32
+        - ipBlock:
+            cidr: 10.66.0.12/32
+        - ipBlock:
+            cidr: 10.66.0.254/32
+      ports:
+        - port: 6443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-control-plane-lab-api-egress
+  namespace: lab
+spec:
+  # admin-kubeconfig-generator is intentionally absent while users: []: its
+  # parent-API-only path does not contact the child. If chart users are added,
+  # add that component here in the same reviewed change.
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-control-plane
+      app.kubernetes.io/instance: control-plane
+    matchExpressions:
+      - key: app.kubernetes.io/component
+        operator: In
+        values:
+          - apiserver
+          - controller-manager
+          - scheduler
+          - bootstrap
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 172.21.0.25/32
+      ports:
+        - port: 6443
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: k8s-control-plane
+              app.kubernetes.io/instance: control-plane
+              app.kubernetes.io/component: apiserver
+      ports:
+        - port: 6443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-tailnet-proxy-lab-api-egress
+  namespace: lab
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: lab-apiserver-tailnet
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 172.21.0.25/32
+      ports:
+        - port: 6443
+          protocol: TCP
+        - port: 8091
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: k8s-control-plane
+              app.kubernetes.io/instance: control-plane
+              app.kubernetes.io/component: apiserver
+      ports:
+        - port: 6443
+          protocol: TCP
+        - port: 8091
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-proxy-ingress
+  namespace: lab
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-control-plane
+      app.kubernetes.io/instance: control-plane
+      app.kubernetes.io/component: apiserver
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: k8s-control-plane
+              app.kubernetes.io/instance: control-plane
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - apiserver
+                  - controller-manager
+                  - scheduler
+                  - bootstrap
+      ports:
+        - port: 6443
+          protocol: TCP
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: lab-apiserver-tailnet
+      ports:
+        - port: 6443
+          protocol: TCP
+        - port: 8091
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-apiserver-etcd-egress
+  namespace: lab
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: k8s-control-plane
+      app.kubernetes.io/instance: control-plane
+      app.kubernetes.io/component: apiserver
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.66.0.10/32
+        - ipBlock:
+            cidr: 10.66.0.11/32
+        - ipBlock:
+            cidr: 10.66.0.12/32
+      ports:
+        - port: 2379
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-tailnet-proxy-public-egress
+  namespace: lab
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: lab-apiserver-tailnet
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 0.0.0.0/8
+              - 10.0.0.0/8
+              - 100.64.0.0/10
+              - 127.0.0.0/8
+              - 169.254.0.0/16
+              - 172.16.0.0/12
+              - 192.0.0.0/24
+              - 192.0.2.0/24
+              - 192.168.0.0/16
+              - 198.18.0.0/15
+              - 198.51.100.0/24
+              - 203.0.113.0/24
+              - 224.0.0.0/4
+              - 240.0.0.0/4
+      ports:
+        - port: 443
+          protocol: TCP

--- a/fabric/cluster/lab/foundation/tailnet.yaml
+++ b/fabric/cluster/lab/foundation/tailnet.yaml
@@ -1,0 +1,191 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lab-apiserver-ts-serve-config
+  namespace: lab
+data:
+  serve.json: |
+    {
+      "TCP": {
+        "6443": {
+          "TCPForward": "apiserver.lab.svc.cluster.fabric.internal:6443"
+        },
+        "8091": {
+          "TCPForward": "apiserver.lab.svc.cluster.fabric.internal:8091"
+        }
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: lab-apiserver-ts-state
+  namespace: lab
+  annotations:
+    kustomize.toolkit.fluxcd.io/ssa: Merge
+type: Opaque
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: lab-apiserver-tailnet
+  namespace: lab
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: lab-apiserver-tailnet-state
+  namespace: lab
+rules:
+  - apiGroups: [""]
+    resourceNames: [lab-apiserver-ts-state]
+    resources: [secrets]
+    verbs: [get, update, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: lab-apiserver-tailnet-state
+  namespace: lab
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: lab-apiserver-tailnet-state
+subjects:
+  - kind: ServiceAccount
+    name: lab-apiserver-tailnet
+    namespace: lab
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: lab-apiserver-tailnet
+  namespace: lab
+  labels:
+    app.kubernetes.io/component: tailnet-proxy
+    app.kubernetes.io/instance: lab
+    app.kubernetes.io/name: lab-apiserver-tailnet
+    app.kubernetes.io/part-of: lab-control-plane
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: lab-apiserver-tailnet
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: tailnet-proxy
+        app.kubernetes.io/instance: lab
+        app.kubernetes.io/name: lab-apiserver-tailnet
+        app.kubernetes.io/part-of: lab-control-plane
+    spec:
+      automountServiceAccountToken: true
+      enableServiceLinks: false
+      serviceAccountName: lab-apiserver-tailnet
+      priorityClassName: system-cluster-critical
+      terminationGracePeriodSeconds: 60
+      nodeSelector:
+        fabric.samcday.com/platform: "true"
+        kubernetes.io/os: linux
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchFields:
+                  - key: metadata.name
+                    operator: In
+                    values:
+                      - fabric-az1-svc1
+                      - fabric-az1-svc2
+      tolerations:
+        - effect: NoSchedule
+          key: fabric.samcday.com/platform
+          operator: Equal
+          value: "true"
+      securityContext:
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: tailscale
+          image: ghcr.io/tailscale/tailscale:v1.86.5@sha256:9e2bfdd9e2ce724df53f976d06a4a9933aa730dc655ace42798f4c73735d1cac
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: HOME
+              value: /tmp
+            - name: TS_ACCEPT_DNS
+              value: "false"
+            - name: TS_AUTH_ONCE
+              value: "true"
+            - name: TS_ENABLE_HEALTH_CHECK
+              value: "true"
+            - name: TS_EXTRA_ARGS
+              value: --login-server=https://headscale.tail22d0a0.ts.net --advertise-tags=tag:lab-apiserver --accept-routes=false --ssh=false
+            - name: TS_HOSTNAME
+              value: lab-apiserver
+            - name: TS_AUTHKEY
+              valueFrom:
+                secretKeyRef:
+                  name: lab-apiserver-ts-auth
+                  key: authkey
+                  optional: false
+            - name: TS_KUBE_SECRET
+              value: lab-apiserver-ts-state
+            - name: TS_SERVE_CONFIG
+              value: /config/serve.json
+            - name: TS_SOCKET
+              value: /var/run/tailscale/tailscaled.sock
+            - name: TS_TAILSCALED_EXTRA_ARGS
+              value: --no-logs-no-support
+            - name: TS_USERSPACE
+              value: "true"
+          ports:
+            - containerPort: 9002
+              name: health
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            failureThreshold: 3
+            periodSeconds: 5
+            timeoutSeconds: 2
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            readOnlyRootFilesystem: true
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /config
+              name: serve-config
+              readOnly: true
+            - mountPath: /tmp
+              name: tmp
+            - mountPath: /var/run/tailscale
+              name: run
+      volumes:
+        - configMap:
+            name: lab-apiserver-ts-serve-config
+          name: serve-config
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+          name: run
+        - emptyDir:
+            medium: Memory
+            sizeLimit: 16Mi
+          name: tmp

--- a/fabric/cluster/lab/tests/run
+++ b/fabric/cluster/lab/tests/run
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+test_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+python=/usr/bin/python3
+if [[ ! -x $python ]]; then
+  python=$(command -v python3)
+fi
+
+PYTHONDONTWRITEBYTECODE=1 "$python" -B -m unittest discover \
+  --start-directory "$test_dir" \
+  --pattern 'test_*.py'

--- a/fabric/cluster/lab/tests/test_contract.py
+++ b/fabric/cluster/lab/tests/test_contract.py
@@ -1,0 +1,165 @@
+import pathlib
+import subprocess
+import unittest
+
+import yaml
+
+
+REPO = pathlib.Path(__file__).resolve().parents[4]
+
+
+def documents(path):
+    return [item for item in yaml.safe_load_all(path.read_text()) if item]
+
+
+def render(relative):
+    result = subprocess.run(
+        ["kubectl", "kustomize", str(REPO / relative)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [item for item in yaml.safe_load_all(result.stdout) if item]
+
+
+def object_named(items, kind, name, namespace=None):
+    for item in items:
+        metadata = item.get("metadata", {})
+        if (
+            item.get("kind") == kind
+            and metadata.get("name") == name
+            and (namespace is None or metadata.get("namespace") == namespace)
+        ):
+            return item
+    raise AssertionError(f"missing {kind}/{name}")
+
+
+class LabFoundationContract(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.foundation = render("fabric/cluster/lab/foundation")
+
+    def test_runtime_owned_handoffs_use_merge_ownership(self):
+        state = object_named(
+            self.foundation, "Secret", "lab-apiserver-ts-state", "lab"
+        )
+        endpoint = object_named(
+            self.foundation, "ConfigMap", "lab-control-plane-endpoint", "lab"
+        )
+        annotation = "kustomize.toolkit.fluxcd.io/ssa"
+        self.assertEqual(state["metadata"]["annotations"][annotation], "Merge")
+        self.assertEqual(endpoint["metadata"]["annotations"][annotation], "Merge")
+        self.assertNotIn("data", state)
+        self.assertNotIn("data", endpoint)
+        self.assertEqual(
+            endpoint["metadata"]["labels"]["reconcile.fluxcd.io/watch"],
+            "Enabled",
+        )
+
+    def test_tenant_and_tailnet_identity_are_exact(self):
+        tenant = object_named(self.foundation, "EtcdTenant", "apiserver", "lab")
+        self.assertEqual(tenant["spec"]["secretName"], "apiserver-etcd-client")
+        self.assertEqual(
+            tenant["spec"]["clusterRef"],
+            {"name": "fabric-etcd", "namespace": "etcdetcetc"},
+        )
+        proxy = object_named(
+            self.foundation, "Deployment", "lab-apiserver-tailnet", "lab"
+        )
+        pod = proxy["spec"]["template"]["spec"]
+        container = pod["containers"][0]
+        env = {entry["name"]: entry.get("value") for entry in container["env"]}
+        self.assertEqual(proxy["spec"]["strategy"]["type"], "Recreate")
+        self.assertTrue(container["securityContext"]["runAsNonRoot"])
+        self.assertEqual(container["securityContext"]["capabilities"]["drop"], ["ALL"])
+        self.assertEqual(env["TS_HOSTNAME"], "lab-apiserver")
+        self.assertEqual(env["TS_KUBE_SECRET"], "lab-apiserver-ts-state")
+        self.assertEqual(env["TS_SOCKET"], "/var/run/tailscale/tailscaled.sock")
+        self.assertIn("tag:lab-apiserver", env["TS_EXTRA_ARGS"])
+
+    def test_publisher_is_atomic_and_change_driven(self):
+        publisher = object_named(
+            self.foundation,
+            "Deployment",
+            "lab-apiserver-endpoint-publisher",
+            "lab",
+        )
+        script = publisher["spec"]["template"]["spec"]["containers"][0]["args"][0]
+        self.assertIn("lab-apiserver.tailnet.hub.samcday.com", script)
+        self.assertIn("externalHostname", script)
+        self.assertIn("externalIP", script)
+        self.assertIn("$2 >= 64 && $2 <= 127", script)
+        compare = script.index('if [ "$current" != "$expected" ]; then')
+        apply = script.index("kubectl apply --server-side")
+        self.assertLess(compare, apply)
+
+    def test_public_proxy_egress_is_tcp_443_only(self):
+        policy = object_named(
+            self.foundation,
+            "NetworkPolicy",
+            "allow-tailnet-proxy-public-egress",
+            "lab",
+        )
+        self.assertEqual(
+            policy["spec"]["egress"][0]["ports"],
+            [{"port": 443, "protocol": "TCP"}],
+        )
+
+
+class LabControlPlaneContract(unittest.TestCase):
+    def test_values_are_pinned_and_hardened(self):
+        manifest = documents(
+            REPO / "fabric/cluster/lab/control-plane/control-plane-values.yaml"
+        )[0]
+        values = yaml.safe_load(manifest["data"]["values.yaml"])
+        self.assertEqual(values["version"], "1.36.3")
+        self.assertEqual(values["clusterCIDRs"], ["172.26.0.0/16"])
+        self.assertEqual(values["serviceCIDRs"], ["172.25.0.0/16"])
+        self.assertEqual(values["serviceIP"], "172.25.0.1")
+        self.assertEqual(values["adminKubeconfig"]["schedule"], "@daily")
+        self.assertEqual(
+            values["adminKubeconfig"]["concurrencyPolicy"], "Forbid"
+        )
+        self.assertEqual(values["apiServer"]["service"]["spec"]["clusterIP"], "172.21.0.25")
+        self.assertTrue(values["parentWorkloads"]["enabled"])
+        self.assertEqual(
+            values["parentWorkloads"]["deployment"]["pdb"]["spec"],
+            {"minAvailable": 1},
+        )
+        self.assertFalse(values["monitoring"]["podMonitors"]["enabled"])
+        self.assertEqual(values["konnectivity"]["server"]["clientIdentity"], "dedicated")
+        for component in ("apiServer", "controllerManager", "scheduler"):
+            self.assertRegex(
+                values[component]["image"]["digest"], r"^sha256:[0-9a-f]{64}$"
+            )
+
+    def test_helm_values_handoffs_are_ordered(self):
+        release = documents(
+            REPO / "fabric/cluster/lab/control-plane/release.yaml"
+        )[0]
+        refs = [entry["name"] for entry in release["spec"]["valuesFrom"]]
+        self.assertEqual(
+            refs,
+            ["control-plane-values", "apiserver-etcd", "lab-control-plane-endpoint"],
+        )
+        self.assertEqual(release["spec"]["driftDetection"]["mode"], "enabled")
+
+    def test_flux_stages_are_safely_suspended(self):
+        children = documents(REPO / "fabric/cluster/flux-system/children.yaml")
+        foundation = object_named(
+            children, "Kustomization", "fabric-lab-foundation", "flux-system"
+        )
+        control_plane = object_named(
+            children, "Kustomization", "fabric-lab-control-plane", "flux-system"
+        )
+        self.assertTrue(foundation["spec"]["suspend"])
+        self.assertTrue(control_plane["spec"]["suspend"])
+        self.assertNotIn("wait", foundation["spec"])
+        self.assertEqual(
+            [item["name"] for item in control_plane["spec"]["dependsOn"]],
+            ["fabric-lab-foundation"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/fabric/cluster/platform/namespaces.yaml
+++ b/fabric/cluster/platform/namespaces.yaml
@@ -33,3 +33,16 @@ metadata:
     pod-security.kubernetes.io/enforce-version: v1.36
     pod-security.kubernetes.io/warn: restricted
     pod-security.kubernetes.io/warn-version: v1.36
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: lab
+  labels:
+    fabric.samcday.com/k8s-control-plane: "true"
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v1.36
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.36
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v1.36

--- a/fabric/pki/etcdetcetc/verify-foundation
+++ b/fabric/pki/etcdetcetc/verify-foundation
@@ -106,7 +106,7 @@ cluster="$repo_root/fabric/cluster/etcdetcetc/runtime/cluster.yaml"
    $(yq -r '.spec.serverCAConfigMapRef.name' "$cluster") == fabric-etcd-server-ca &&
    $(yq -r '.spec.tenantTls.issuerRef.kind' "$cluster") == ClusterIssuer &&
    $(yq -r '.spec.tenantTls.issuerRef.name' "$cluster") == fabric-etcd-client-v1 &&
-   $(yq -r '.spec.allowedNamespaces | join(",")' "$cluster") == etcdetcetc-smoke ]] ||
+   $(yq -r '.spec.allowedNamespaces | join(",")' "$cluster") == 'etcdetcetc-smoke,lab' ]] ||
   die 'Fabric EtcdCluster trust or namespace contract differs'
 expected_endpoints='https://fabric-az1-cp1.fabric.internal:2379,https://fabric-az1-cp2.fabric.internal:2379,https://fabric-az1-cp3.fabric.internal:2379'
 [[ $(yq -r '.spec.endpoints | join(",")' "$cluster") == "$expected_endpoints" ]] ||
@@ -216,7 +216,11 @@ jq -e '
     {"apiVersion": "v1", "kind": "Namespace",
       "metadata": {"name": "etcdetcetc", "labels": restricted_labels}},
     {"apiVersion": "v1", "kind": "Namespace",
-      "metadata": {"name": "etcdetcetc-smoke", "labels": restricted_labels}}
+      "metadata": {"name": "etcdetcetc-smoke", "labels": restricted_labels}},
+    {"apiVersion": "v1", "kind": "Namespace",
+      "metadata": {"name": "lab", "labels": (restricted_labels + {
+        "fabric.samcday.com/k8s-control-plane": "true"
+      })}}
   ]
 ' >/dev/null <<<"$namespace_objects" ||
   die 'Fabric foundation Namespaces must be the exact restricted-v1.36 set'
@@ -357,9 +361,9 @@ if [[ $activation_phase == controller-active || $activation_phase == runtime-act
     die 'active Fabric controller must use a canonical non-bootstrap tag-and-digest image pin'
 fi
 [[ $(yq -r 'select(.metadata.name == "etcdetcetc") | .spec.values.allowedNamespaces | join(",")' \
-  "$release") == 'etcdetcetc,etcdetcetc-smoke' &&
+  "$release") == 'etcdetcetc,etcdetcetc-smoke,lab' &&
    $(yq -r 'select(.metadata.name == "etcdetcetc") | .spec.values.managedNamespaces | join(",")' \
-  "$release") == etcdetcetc-smoke &&
+  "$release") == 'etcdetcetc-smoke,lab' &&
    $(yq -r 'select(.metadata.name == "etcdetcetc") | (.spec.values.clusterNamespaces // []) | join(",")' \
   "$release") == '' &&
    $(yq -r 'select(.metadata.name == "etcdetcetc") | .spec.values.legacyClusterWideCoreWatches' \

--- a/fabric/router/tests/run
+++ b/fabric/router/tests/run
@@ -6,6 +6,16 @@ export PYTHONDONTWRITEBYTECODE=1
 repo_root=$(cd -- "$(dirname -- "$0")/../../.." && pwd)
 cd -- "$repo_root"
 
-python3 -B -m unittest discover \
+python_bin=${PYTHON:-python3}
+if ! "$python_bin" -c 'import yaml' >/dev/null 2>&1; then
+  if /usr/bin/python3 -c 'import yaml' >/dev/null 2>&1; then
+    python_bin=/usr/bin/python3
+  else
+    echo "PyYAML is required to run the Fabric router tests" >&2
+    exit 1
+  fi
+fi
+
+"$python_bin" -B -m unittest discover \
   --start-directory fabric/router/tests \
   --pattern 'test_*.py'

--- a/fabric/router/tests/test_etcd_policy_rollout.py
+++ b/fabric/router/tests/test_etcd_policy_rollout.py
@@ -1426,6 +1426,19 @@ guard_live
                     },
                 }
                 for name in ("cert-manager", "etcdetcetc", "etcdetcetc-smoke")
+            ]
+            + [
+                {
+                    "apiVersion": "v1",
+                    "kind": "Namespace",
+                    "metadata": {
+                        "name": "lab",
+                        "labels": {
+                            **restricted_labels,
+                            "fabric.samcday.com/k8s-control-plane": "true",
+                        },
+                    },
+                }
             ],
         )
 

--- a/hub/cluster/headscale/acls.json
+++ b/hub/cluster/headscale/acls.json
@@ -34,6 +34,7 @@
         "tag:edge-au-east-node": [],
         "tag:fabric-subnet-router": ["sam@"],
         "tag:hub-apiserver": [],
+        "tag:lab-apiserver": [],
         "tag:labgrid-coordinator": []
     },
     "autoApprovers": {

--- a/hub/cluster/headscale/main.tf
+++ b/hub/cluster/headscale/main.tf
@@ -40,6 +40,10 @@ resource "headscale_user" "hub" {
   name = "hub"
 }
 
+resource "headscale_user" "lab" {
+  name = "lab"
+}
+
 resource "headscale_user" "sam" {
   name = "sam"
 }
@@ -112,6 +116,14 @@ resource "headscale_pre_auth_key" "hub_apiserver_stable" {
   reusable       = true
   ephemeral      = false
   acl_tags       = ["tag:hub-apiserver"]
+}
+
+resource "headscale_pre_auth_key" "lab_apiserver_stable" {
+  user           = headscale_user.lab.id
+  time_to_expire = "520w"
+  reusable       = true
+  ephemeral      = false
+  acl_tags       = ["tag:lab-apiserver"]
 }
 
 resource "kubernetes_secret" "cloud-cluster-node-preauth" {
@@ -199,5 +211,16 @@ resource "kubernetes_secret" "hub_apiserver_preauth" {
 
   data = {
     authkey = headscale_pre_auth_key.hub_apiserver_stable.key
+  }
+}
+
+resource "kubernetes_secret" "lab_apiserver_preauth" {
+  metadata {
+    name      = "lab-apiserver-ts-auth"
+    namespace = "headscale"
+  }
+
+  data = {
+    authkey = headscale_pre_auth_key.lab_apiserver_stable.key
   }
 }

--- a/hub/cluster/headscale/tofu.yaml
+++ b/hub/cluster/headscale/tofu.yaml
@@ -39,6 +39,7 @@ rules:
     - edge-au-east-node-ts-auth
     - conduit-ts-auth
     - hub-apiserver-ts-auth
+    - lab-apiserver-ts-auth
     - labgrid-ts-auth
     - wasmcloud-nats-ts-auth
   verbs: [patch, update, get]

--- a/scripts/handoff-lab-apiserver-auth
+++ b/scripts/handoff-lab-apiserver-auth
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+repo_root=$(cd -- "$script_dir/.." && pwd -P)
+readonly target_relative=fabric/cluster/lab/foundation/apiserver-ts-auth.sops.yaml
+readonly target="$repo_root/$target_relative"
+cd -- "$repo_root"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/handoff-lab-apiserver-auth [--force]
+
+Read the Terraform-managed lab apiserver Headscale preauth key from Hub and
+write it only as a SOPS-encrypted Secret for Fabric. Plaintext exists only in
+process memory and a pipe; the temporary output is encrypted and held in tmpfs.
+
+Use --force only when intentionally rotating an existing encrypted handoff.
+EOF
+}
+
+die() {
+  printf 'handoff-lab-apiserver-auth: %s\n' "$*" >&2
+  exit 1
+}
+
+force=false
+case ${1:-} in
+  '') ;;
+  --force) force=true ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac
+[[ $# -le 1 ]] || die 'too many arguments'
+
+for command in base64 grep install mktemp sops yq; do
+  command -v "$command" >/dev/null || die "required command is unavailable: $command"
+done
+[[ -x $repo_root/scripts/ik ]] || die 'scripts/ik is unavailable'
+[[ -d $repo_root/fabric/cluster/lab/foundation ]] ||
+  die 'Fabric lab foundation directory does not exist'
+[[ -d /dev/shm && -w /dev/shm ]] || die '/dev/shm tmpfs is unavailable or unwritable'
+if [[ -e $target && $force != true ]]; then
+  die "$target_relative already exists; use --force only for an intentional rotation"
+fi
+
+umask 077
+handoff_tmp_dir=$(mktemp -d /dev/shm/lab-apiserver-auth.XXXXXXXX)
+encrypted_tmp=$handoff_tmp_dir/apiserver-ts-auth.sops.yaml
+encoded=''
+auth_key=''
+cleanup() {
+  encoded=''
+  auth_key=''
+  if [[ -n ${handoff_tmp_dir:-} && -d $handoff_tmp_dir ]]; then
+    rm -f -- "$encrypted_tmp"
+    rmdir -- "$handoff_tmp_dir"
+  fi
+}
+trap cleanup EXIT HUP INT TERM
+
+encoded=$(
+  "$repo_root/scripts/ik" --context=hub --namespace=headscale \
+    get secret lab-apiserver-ts-auth --output=jsonpath='{.data.authkey}'
+)
+[[ -n $encoded ]] || die 'Hub Secret headscale/lab-apiserver-ts-auth has no authkey'
+auth_key=$(printf '%s' "$encoded" | base64 --decode) || die 'Hub authkey is not valid base64'
+[[ $auth_key =~ ^hskey-auth-[A-Za-z0-9_-]{16,}$ ]] ||
+  die 'Hub authkey does not have the expected hskey-auth format'
+
+printf '%s\n' \
+  'apiVersion: v1' \
+  'kind: Secret' \
+  'metadata:' \
+  '  name: lab-apiserver-ts-auth' \
+  '  namespace: lab' \
+  'type: Opaque' \
+  'stringData:' \
+  "  authkey: $auth_key" |
+  sops encrypt \
+    --filename-override "$target_relative" \
+    --input-type yaml \
+    --output-type yaml \
+    /dev/stdin >"$encrypted_tmp"
+
+[[ $(sops filestatus "$encrypted_tmp" | yq -r '.encrypted') == true ]] ||
+  die 'SOPS did not report encrypted output'
+! grep -Fq 'hskey-auth-' "$encrypted_tmp" || die 'encrypted output still contains plaintext auth material'
+
+install -m 0600 -- "$encrypted_tmp" "$target"
+printf 'Wrote SOPS-encrypted Fabric handoff: %s\n' "$target_relative"


### PR DESCRIPTION
## What changed

- harden `charts/k8s-control-plane` for hosted control planes while preserving existing release renders
- add the suspended Fabric `lab` foundation and control-plane stages
- add the TLS etcdetcetc tenant contract, Tailnet proxy, endpoint publisher, and least-privilege network policy
- add the Hub Headscale identity and SOPS-only credential handoff helper
- document the accepted temporary flat-L2 risk and spread Fabric CoreDNS across service nodes

## Why

Fabric's first hosted tenant needs a minimal, production-shaped control plane backed by the shared gold-plated etcd and published over the tailnet. This first merge is deliberately safe: both new child Kustomizations remain suspended and no placeholder credential is committed.

## Validation

- `charts/k8s-control-plane/tests/run` (15 tests)
- `fabric/cluster/lab/tests/run` (7 tests)
- `fabric/pki/etcdetcetc/tests/run` (11 tests)
- `fabric/pki/etcdetcetc/verify-foundation`
- `fabric/router/tests/run` (189 tests)
- affected Kustomize renders, exact lab Helm render, Helm lint
- OpenTofu validation, ShellCheck, image digest verification, `git diff --check`
