### PR TITLE
Activate lab control-plane foundation

### DIFF
--- a/fabric/cluster/flux-system/children.yaml
+++ b/fabric/cluster/flux-system/children.yaml
@@ -205,7 +205,7 @@ spec:
   # SOPS Secret to lab/foundation/kustomization.yaml, then (4) unsuspend only
   # this foundation and wait for the tenant, Tailnet proxy, and endpoint
   # publisher to become Ready.
-  suspend: true
+  suspend: false
   decryption:
     provider: sops
     secretRef:

--- a/fabric/cluster/lab/foundation/README.md
+++ b/fabric/cluster/lab/foundation/README.md
@@ -5,8 +5,7 @@ workers or child-cluster add-ons. It provisions the etcdetcetc tenant, the
 Tailnet TCP proxy, and an endpoint publisher that writes the proxy's dynamically
 assigned CGNAT IPv4 into `lab-control-plane-endpoint`.
 
-Both `fabric-lab-foundation` and `fabric-lab-control-plane` are committed
-suspended. Activation is deliberately attended:
+Initial activation is deliberately attended and split across two Flux stages:
 
 1. Reconcile the Hub Headscale Terraform until its
    `headscale/lab-apiserver-ts-auth` Secret exists.

--- a/fabric/cluster/lab/foundation/apiserver-ts-auth.sops.yaml
+++ b/fabric/cluster/lab/foundation/apiserver-ts-auth.sops.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: lab-apiserver-ts-auth
+    namespace: lab
+type: Opaque
+stringData:
+    authkey: ENC[AES256_GCM,data:jb22aALi5Z8bW1f90rltx3PJNK+fvRAw2I1B1BL3rqkTjzgR9YKNNzRQS9TwaF0xBUCbG+asIa2Dkh0ppKhj72ulBSgS6wr7YzBnjzxRqiyHNGWOEZ6tpA==,iv:apgXu2HarudAvHQHN8kpUyAXCElG3uIkENBfu2zn70M=,tag:UCTU8XOl8UZnGr/8IIwtkA==,type:str]
+sops:
+    age:
+        - recipient: age1r8tha72lm6j96pre8qrlxj2nyyzm9cq38umh9dcd2kf5hhjnqsfqe6saex
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXTDN3N3dEdWVVRURYMEVm
+            K1pqbi9wb3pacm1qYXJDeHA1UVVEQ2dTZHp3CjVLRXh5N1AxOFBEK01kaDhBMWxu
+            dG04a25UYzRrRXBLWk00RkRhMlptdmMKLS0tIHRKc3dDUkZPMXFSV1A1RHM2SEV2
+            eUJTRzhoVWZMMm5kSk5aQmwvQ3ZHeHMKFDHnbb2M+mmUaohVNZnY5a5DIG5qpS1A
+            B+0RGikSOnVM9pA+apzbGlajOD7XjxjcDF3wU5QRm5cgjBsZkw6cTg==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age14taxy23wzym2r9jndzsq5h8dx2f5cj5vtusfet2ggjjepp8pkfdqf6mus0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkU3NVZTlwOXpLeE5jWll5
+            ZzkxSG1KajRubE5tK29LYndWN3pYMXlORlF3CkUvWjVPcE9zUEdUYVh1ZHJPbHZx
+            emV3VkIyN0FDMTc2WjNObFdjUjRLV0EKLS0tIHdhQ2lhcFJUb1V0ODNtTTlTU2Zl
+            NytkYUMrZFRqSHJTeWNtWHpibmkyY1UKdLNAyFa/AsOZ0dhAg84UUq+8GJuAxWKa
+            XSYwBUIA6aVzzALGFomarCSDDkTYBhtc2DOh0rgHjcnDixUUGCyZTA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-07-29T00:02:01Z"
+    mac: ENC[AES256_GCM,data:7dzCev1HN9NDBucYY7P4yIbp/A6++ke7GIrFtvPEhONxWeu6wdyvsGJfEBheR/9O2fS7ubBhsx9FKKqRUZZon9q+0IYBECMgQny/v89PyKHILvC3cEYhgI9ZOysMe2Ao7Gu5sH8PViJE5enXUZXEGvkXLSZwCohOmrk4kCwG/U8=,iv:nxwgaMle+3wJmnYYf8pu6fFVSK/rLH1RR+HZk1nsMcQ=,tag:UM0NCCTiBWAz3Oe+J0yGPw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/fabric/cluster/lab/foundation/kustomization.yaml
+++ b/fabric/cluster/lab/foundation/kustomization.yaml
@@ -1,12 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - apiserver-ts-auth.sops.yaml
   - etcd-tenant.yaml
   - endpoint.yaml
   - tailnet.yaml
   - endpoint-publisher.yaml
   - network-policies.yaml
-
-# Activation gate: after scripts/handoff-lab-apiserver-auth creates the
-# encrypted file, add this resource before unsuspending fabric-lab-foundation:
-#   - apiserver-ts-auth.sops.yaml

--- a/fabric/cluster/lab/tests/test_contract.py
+++ b/fabric/cluster/lab/tests/test_contract.py
@@ -145,7 +145,7 @@ class LabControlPlaneContract(unittest.TestCase):
         self.assertEqual(release["spec"]["driftDetection"]["mode"], "enabled")
         self.assertNotIn("force", release["spec"]["upgrade"])
 
-    def test_flux_stages_are_safely_suspended(self):
+    def test_flux_activation_order_is_safe(self):
         children = documents(REPO / "fabric/cluster/flux-system/children.yaml")
         foundation = object_named(
             children, "Kustomization", "fabric-lab-foundation", "flux-system"
@@ -153,8 +153,13 @@ class LabControlPlaneContract(unittest.TestCase):
         control_plane = object_named(
             children, "Kustomization", "fabric-lab-control-plane", "flux-system"
         )
-        self.assertTrue(foundation["spec"]["suspend"])
-        self.assertTrue(control_plane["spec"]["suspend"])
+        self.assertIn(
+            (
+                foundation["spec"]["suspend"],
+                control_plane["spec"]["suspend"],
+            ),
+            ((True, True), (False, True), (False, False)),
+        )
         self.assertNotIn("wait", foundation["spec"])
         self.assertEqual(
             [item["name"] for item in control_plane["spec"]["dependsOn"]],


### PR DESCRIPTION
## What changed

- add the SOPS-encrypted Fabric copy of the Terraform-produced Headscale preauth key
- include that Secret in the lab foundation Kustomization
- unsuspend only `fabric-lab-foundation`; the Helm control plane remains suspended
- make the activation-order contract valid across all three attended rollout states

## Safety gates

This PR is the second rollout stage. It may merge only after Fabric has applied the prerequisite stage. The foundation Kustomization waits for a current-generation TLS EtcdTenant, the Tailnet proxy, and the endpoint publisher before reporting Ready.

## Validation

- SOPS encrypted status and exact Fabric/recovery recipients
- no plaintext Headscale key material in the encrypted manifest
- `kubectl kustomize fabric/cluster/lab/foundation`
- `kubectl kustomize fabric/cluster/flux-system`
- `fabric/cluster/lab/tests/run` (7 tests)
- `git diff --check`
