### PR TITLE
Fix control-plane Job upgrades

### DIFF
--- a/fabric/cluster/lab/control-plane/release.yaml
+++ b/fabric/cluster/lab/control-plane/release.yaml
@@ -21,9 +21,6 @@ spec:
   timeout: 10m
   upgrade:
     cleanupOnFail: true
-    # Jobs in this chart have ttlSecondsAfterFinished and get GC'd between
-    # upgrades; force recreates missing resources instead of patching them.
-    force: true
     remediation:
       retries: 3
   valuesFrom:

--- a/fabric/cluster/lab/tests/test_contract.py
+++ b/fabric/cluster/lab/tests/test_contract.py
@@ -143,6 +143,7 @@ class LabControlPlaneContract(unittest.TestCase):
             ["control-plane-values", "apiserver-etcd", "lab-control-plane-endpoint"],
         )
         self.assertEqual(release["spec"]["driftDetection"]["mode"], "enabled")
+        self.assertNotIn("force", release["spec"]["upgrade"])
 
     def test_flux_stages_are_safely_suspended(self):
         children = documents(REPO / "fabric/cluster/flux-system/children.yaml")

--- a/hub/cluster/cloud-cluster/control-plane.yaml
+++ b/hub/cluster/cloud-cluster/control-plane.yaml
@@ -14,10 +14,6 @@ spec:
         name: infra
         namespace: flux-system
   interval: 1h
-  upgrade:
-    # Jobs in this chart have ttlSecondsAfterFinished and get GC'd between chart
-    # upgrades; force recreates missing resources instead of failing to patch.
-    force: true
   valuesFrom:
     - kind: ConfigMap
       name: control-plane-values

--- a/hub/cluster/cloud-cluster/edge/cluster/edge-au-east-control-plane.yaml
+++ b/hub/cluster/cloud-cluster/edge/cluster/edge-au-east-control-plane.yaml
@@ -12,10 +12,6 @@ spec:
         name: infra
   interval: 1h
   releaseName: edge-edge-au-east-control-plane
-  upgrade:
-    # Jobs in this chart have ttlSecondsAfterFinished and get GC'd between chart
-    # upgrades; force recreates missing resources instead of failing to patch.
-    force: true
   valuesFrom:
     - kind: ConfigMap
       name: edge-au-east-control-plane-values

--- a/hub/cluster/cloud-cluster/edge/parent/edge-au-east-control-plane-legacy.yaml
+++ b/hub/cluster/cloud-cluster/edge/parent/edge-au-east-control-plane-legacy.yaml
@@ -23,10 +23,6 @@ spec:
   # the existing release while the cloud-side HelmRelease adopts it.
   suspend: true
   targetNamespace: edge
-  upgrade:
-    # Jobs in this chart have ttlSecondsAfterFinished and get GC'd between chart
-    # upgrades; force recreates missing resources instead of failing to patch.
-    force: true
   valuesFrom:
     - kind: ConfigMap
       name: edge-au-east-control-plane-values

--- a/hub/cluster/ilumbaclusta/control-plane.yaml
+++ b/hub/cluster/ilumbaclusta/control-plane.yaml
@@ -14,10 +14,6 @@ spec:
         name: infra
         namespace: flux-system
   interval: 1h
-  upgrade:
-    # Jobs in this chart have ttlSecondsAfterFinished and get GC'd between chart
-    # upgrades; force recreates missing resources instead of failing to patch.
-    force: true
   valuesFrom:
     - kind: ConfigMap
       name: control-plane-values


### PR DESCRIPTION
## What changed

Remove release-wide Helm `upgrade.force` from every `k8s-control-plane` HelmRelease, including the staged lab release.

## Root cause

Helm's force replacement sends Job manifests without the server-generated selector fields present on an existing Job. Kubernetes rejects that replacement because the selector is required and immutable. This surfaced when the stage-1 chart revision reached `ilumbaclusta`; cloud upgraded only because its short-lived Jobs had already been garbage-collected.

Ordinary Helm upgrades create missing TTL-garbage-collected Jobs and leave unchanged extant Jobs alone, avoiding the invalid replacement path.

## Validation

- lab contract tests
- active cloud, ilumbaclusta, edge, and lab Kustomize renders
- legacy edge parent render with its existing unrestricted load path
- YAML parsing and `git diff --check`
