### PR TITLE
Make control-plane setup Jobs upgrade-safe

### DIFF
--- a/charts/k8s-control-plane/templates/_helpers.tpl
+++ b/charts/k8s-control-plane/templates/_helpers.tpl
@@ -15,6 +15,15 @@ app.kubernetes.io/instance: {{ .root.Release.Name | quote }}
 app.kubernetes.io/component: {{ .component | quote }}
 {{- end }}
 
+{{/*
+Run-once Jobs cannot be patched after their pod template changes. Include the
+Helm release revision in their names so upgrades create the new Job and retire
+the previous revision instead of attempting an immutable update.
+*/}}
+{{- define "k8s-control-plane.run-once-job-name" -}}
+{{- printf "%s-%d" .component (int .root.Release.Revision) | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
 {{- define "k8s-control-plane.container-security-context" -}}
 {{- $securityContext := dict -}}
 {{- if .root.Values.parentWorkloads.enabled -}}

--- a/charts/k8s-control-plane/templates/admin-kubeconfig.yaml
+++ b/charts/k8s-control-plane/templates/admin-kubeconfig.yaml
@@ -19,7 +19,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: admin-kubeconfig-generator
+  name: {{ include "k8s-control-plane.run-once-job-name" (dict "root" $ "component" "admin-kubeconfig-generator") }}
   {{- if $.Values.parentWorkloads.enabled }}
   annotations:
     helm.toolkit.fluxcd.io/driftDetection: disabled

--- a/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
+++ b/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: advertise-address
+  name: {{ include "k8s-control-plane.run-once-job-name" (dict "root" $ "component" "advertise-address") }}
   {{- if $.Values.parentWorkloads.enabled }}
   annotations:
     helm.toolkit.fluxcd.io/driftDetection: disabled

--- a/charts/k8s-control-plane/templates/bootstrap.yaml
+++ b/charts/k8s-control-plane/templates/bootstrap.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: bootstrap
+  name: {{ include "k8s-control-plane.run-once-job-name" (dict "root" $ "component" "bootstrap") }}
   {{- if $.Values.parentWorkloads.enabled }}
   annotations:
     helm.toolkit.fluxcd.io/driftDetection: disabled

--- a/charts/k8s-control-plane/templates/ca-hash.yaml
+++ b/charts/k8s-control-plane/templates/ca-hash.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: ca-hash
+  name: {{ include "k8s-control-plane.run-once-job-name" (dict "root" $ "component" "ca-hash") }}
   {{- if $.Values.parentWorkloads.enabled }}
   annotations:
     helm.toolkit.fluxcd.io/driftDetection: disabled

--- a/charts/k8s-control-plane/tests/test_hosting_contract.py
+++ b/charts/k8s-control-plane/tests/test_hosting_contract.py
@@ -144,7 +144,7 @@ def workload_pods(rendered: list[dict]) -> dict[tuple[str, str], tuple[dict, dic
 
 
 def embedded_bootstrap(rendered: list[dict]) -> list[dict]:
-    job = object_named(rendered, "Job", "bootstrap")
+    job = object_named(rendered, "Job", "bootstrap-1")
     command = job["spec"]["template"]["spec"]["containers"][0]["command"][-1]
     start = command.index("apiVersion: v1")
     end = command.index("\nHERE\n", start)
@@ -192,10 +192,10 @@ class HostingContractTests(unittest.TestCase):
             ("Deployment", "apiserver"): "apiserver",
             ("Deployment", "controller-manager"): "controller-manager",
             ("Deployment", "kube-scheduler"): "scheduler",
-            ("Job", "bootstrap"): "bootstrap",
-            ("Job", "ca-hash"): "ca-hash",
-            ("Job", "advertise-address"): "advertise-address",
-            ("Job", "admin-kubeconfig-generator"): "admin-kubeconfig-generator",
+            ("Job", "bootstrap-1"): "bootstrap",
+            ("Job", "ca-hash-1"): "ca-hash",
+            ("Job", "advertise-address-1"): "advertise-address",
+            ("Job", "admin-kubeconfig-generator-1"): "admin-kubeconfig-generator",
             ("CronJob", "admin-kubeconfig-generator"): "admin-kubeconfig-generator",
         }
         self.assertEqual(set(workloads), set(expected_components))
@@ -204,7 +204,7 @@ class HostingContractTests(unittest.TestCase):
             ("Deployment", "apiserver"),
             ("Deployment", "controller-manager"),
             ("Deployment", "kube-scheduler"),
-            ("Job", "bootstrap"),
+            ("Job", "bootstrap-1"),
         }
         for key, component in expected_components.items():
             with self.subTest(workload=key):
@@ -213,6 +213,7 @@ class HostingContractTests(unittest.TestCase):
                 self.assertEqual(labels.items() <= document["metadata"]["labels"].items(), True)
                 self.assertEqual(labels.items() <= template["metadata"]["labels"].items(), True)
                 if key[0] == "Job":
+                    self.assertEqual(document["spec"]["ttlSecondsAfterFinished"], 60)
                     self.assertEqual(
                         document["metadata"]["annotations"][
                             "helm.toolkit.fluxcd.io/driftDetection"


### PR DESCRIPTION
## Summary

- give each run-once control-plane setup Job a Helm release-revision suffix
- retain fixed component labels and service-account/RBAC names
- verify every run-once Job has a 60-second completion TTL

This fixes upgrades of existing hosted control planes: Kubernetes Job pod templates are immutable, so a new chart revision must create a new setup Job rather than patch the completed Job from the prior release.

## Verification

- `charts/k8s-control-plane/tests/run`
- `git diff --check`

## Rollout

This is a prerequisite recovery fix discovered while staging the first Fabric-hosted lab control plane. I will merge it, verify the existing control planes recover, then continue the guarded lab foundation/control-plane activation.