### PR TITLE
Let Helm retire control-plane setup Jobs

### DIFF
--- a/charts/k8s-control-plane/files/admin-kubeconfig-generator.yaml
+++ b/charts/k8s-control-plane/files/admin-kubeconfig-generator.yaml
@@ -122,4 +122,3 @@ template:
           name: {{ $certSecretName }}-kubeconfig-external
       {{- end }}
     restartPolicy: OnFailure
-ttlSecondsAfterFinished: 60

--- a/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
+++ b/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
@@ -57,7 +57,6 @@ spec:
         - name: tmp
           emptyDir: {}
       {{- end }}
-  ttlSecondsAfterFinished: 60
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/k8s-control-plane/templates/bootstrap.yaml
+++ b/charts/k8s-control-plane/templates/bootstrap.yaml
@@ -65,4 +65,3 @@ spec:
           emptyDir: {}
         {{- end }}
       restartPolicy: OnFailure
-  ttlSecondsAfterFinished: 60

--- a/charts/k8s-control-plane/templates/ca-hash.yaml
+++ b/charts/k8s-control-plane/templates/ca-hash.yaml
@@ -57,7 +57,6 @@ spec:
         - name: tmp
           emptyDir: {}
         {{- end }}
-  ttlSecondsAfterFinished: 60
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/k8s-control-plane/tests/test_hosting_contract.py
+++ b/charts/k8s-control-plane/tests/test_hosting_contract.py
@@ -213,7 +213,7 @@ class HostingContractTests(unittest.TestCase):
                 self.assertEqual(labels.items() <= document["metadata"]["labels"].items(), True)
                 self.assertEqual(labels.items() <= template["metadata"]["labels"].items(), True)
                 if key[0] == "Job":
-                    self.assertEqual(document["spec"]["ttlSecondsAfterFinished"], 60)
+                    self.assertNotIn("ttlSecondsAfterFinished", document["spec"])
                     self.assertEqual(
                         document["metadata"]["annotations"][
                             "helm.toolkit.fluxcd.io/driftDetection"


### PR DESCRIPTION
## Summary

- remove the 60-second TTL from the four run-once control-plane setup Jobs
- keep the release-revision naming added in #49
- assert the hosting contract does not enable TTL cleanup

Helm waits for these Jobs as part of the release. If a fast Job expires while a slower Job is still running, Helm fails the upgrade because the completed Job disappeared. Revisioned Job names already allow Helm to retire the prior set safely during the next upgrade.

## Verification

- `charts/k8s-control-plane/tests/run`
- `git diff --check`

## Rollout

This follows the live recovery validation for #49. I will merge it and confirm the existing hosted control planes are Ready before continuing the Fabric lab activation.