### PR TITLE
Reuse the published advertise address during DNS outages

### DIFF
--- a/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
+++ b/charts/k8s-control-plane/templates/apiserver/advertise-address.yaml
@@ -42,6 +42,11 @@ spec:
             - |
               {{- if $.Values.externalHostname }}
               until ip=$(getent ahostsv4 {{ $.Values.externalHostname | quote }} | awk '{print $1; exit}') && [[ -n "$ip" ]]; do
+                # Preserve a previously published endpoint when an otherwise
+                # healthy control plane is upgraded during a DNS outage.
+                if ip=$(kubectl get configmap advertise-address -o jsonpath='{.data.value}' 2>/dev/null) && [[ -n "$ip" ]]; then
+                  break
+                fi
                 sleep 5
               done
               {{- else }}

--- a/charts/k8s-control-plane/tests/test_hosting_contract.py
+++ b/charts/k8s-control-plane/tests/test_hosting_contract.py
@@ -287,6 +287,10 @@ class HostingContractTests(unittest.TestCase):
         self.assertEqual(exporter["spec"]["schedule"], "@daily")
         self.assertEqual(exporter["spec"]["concurrencyPolicy"], "Forbid")
 
+        advertiser = object_named(self.hardened, "Job", "advertise-address-1")
+        command = advertiser["spec"]["template"]["spec"]["containers"][0]["command"][-1]
+        self.assertIn("kubectl get configmap advertise-address", command)
+
     def test_dedicated_konnectivity_identity_is_child_scoped(self) -> None:
         certificate = object_named(self.hardened, "Certificate", "konnectivity-server")
         self.assertEqual(certificate["spec"]["commonName"], "system:konnectivity-server")


### PR DESCRIPTION
## Summary

- prefer current DNS resolution when refreshing a hosted API server's advertised address
- fall back to the already-published `advertise-address` ConfigMap during a DNS outage
- retain the existing retry behavior when neither source is available

This lets an otherwise healthy hosted control plane upgrade without being blocked by transient loss of its public DNS record. A fresh control plane still waits until its endpoint is published because it has no existing ConfigMap.

## Verification

- `charts/k8s-control-plane/tests/run`
- `git diff --check`

## Rollout

This is the final recovery guard discovered while validating the existing ilumbaclusta control plane before enabling the Fabric lab foundation.