### PR TITLE
Fix lab service-node affinity

### DIFF
--- a/fabric/cluster/lab/foundation/endpoint-publisher.yaml
+++ b/fabric/cluster/lab/foundation/endpoint-publisher.yaml
@@ -70,8 +70,8 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchFields:
-                  - key: metadata.name
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
                     operator: In
                     values:
                       - fabric-az1-svc1

--- a/fabric/cluster/lab/foundation/tailnet.yaml
+++ b/fabric/cluster/lab/foundation/tailnet.yaml
@@ -94,8 +94,8 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-              - matchFields:
-                  - key: metadata.name
+              - matchExpressions:
+                  - key: kubernetes.io/hostname
                     operator: In
                     values:
                       - fabric-az1-svc1

--- a/fabric/cluster/lab/tests/test_contract.py
+++ b/fabric/cluster/lab/tests/test_contract.py
@@ -93,6 +93,30 @@ class LabFoundationContract(unittest.TestCase):
         apply = script.index("kubectl apply --server-side")
         self.assertLess(compare, apply)
 
+    def test_foundation_workloads_target_service_nodes_by_hostname(self):
+        expected = [
+            {
+                "key": "kubernetes.io/hostname",
+                "operator": "In",
+                "values": ["fabric-az1-svc1", "fabric-az1-svc2"],
+            }
+        ]
+        for name in (
+            "lab-apiserver-tailnet",
+            "lab-apiserver-endpoint-publisher",
+        ):
+            with self.subTest(deployment=name):
+                deployment = object_named(
+                    self.foundation, "Deployment", name, "lab"
+                )
+                term = deployment["spec"]["template"]["spec"]["affinity"][
+                    "nodeAffinity"
+                ]["requiredDuringSchedulingIgnoredDuringExecution"][
+                    "nodeSelectorTerms"
+                ][0]
+                self.assertEqual(term["matchExpressions"], expected)
+                self.assertNotIn("matchFields", term)
+
     def test_public_proxy_egress_is_tcp_443_only(self):
         policy = object_named(
             self.foundation,


### PR DESCRIPTION
## Summary

- select the two Fabric service nodes with the standard `kubernetes.io/hostname` label
- replace the invalid multi-value `matchFields: metadata.name In` selector
- cover both foundation Deployments with a contract test

The Fabric API rejected the previous selector during Flux server-side dry-run, before any lab foundation resources were created.

## Verification

- `fabric/cluster/lab/tests/run`
- `kubectl kustomize fabric/cluster/lab/foundation`
- `git diff --check`

## Rollout

I will merge this and continue watching the already-enabled lab foundation Kustomization to readiness. The lab control-plane Kustomization remains suspended.