### PR TITLE
Use the lab auth key's forced Headscale tag

### DIFF
--- a/fabric/cluster/lab/foundation/tailnet.yaml
+++ b/fabric/cluster/lab/foundation/tailnet.yaml
@@ -124,7 +124,7 @@ spec:
             - name: TS_ENABLE_HEALTH_CHECK
               value: "true"
             - name: TS_EXTRA_ARGS
-              value: --login-server=https://headscale.tail22d0a0.ts.net --advertise-tags=tag:lab-apiserver --accept-routes=false --ssh=false
+              value: --login-server=https://headscale.tail22d0a0.ts.net --accept-routes=false --ssh=false
             - name: TS_HOSTNAME
               value: lab-apiserver
             - name: TS_AUTHKEY

--- a/fabric/cluster/lab/tests/test_contract.py
+++ b/fabric/cluster/lab/tests/test_contract.py
@@ -75,7 +75,12 @@ class LabFoundationContract(unittest.TestCase):
         self.assertEqual(env["TS_HOSTNAME"], "lab-apiserver")
         self.assertEqual(env["TS_KUBE_SECRET"], "lab-apiserver-ts-state")
         self.assertEqual(env["TS_SOCKET"], "/var/run/tailscale/tailscaled.sock")
-        self.assertIn("tag:lab-apiserver", env["TS_EXTRA_ARGS"])
+        self.assertNotIn("--advertise-tags", env["TS_EXTRA_ARGS"])
+        headscale = (REPO / "hub/cluster/headscale/main.tf").read_text()
+        key = headscale.split(
+            'resource "headscale_pre_auth_key" "lab_apiserver_stable" {'
+        )[1].split("\n}", 1)[0]
+        self.assertIn('acl_tags       = ["tag:lab-apiserver"]', key)
 
     def test_publisher_is_atomic_and_change_driven(self):
         publisher = object_named(


### PR DESCRIPTION
## Summary

- stop requesting `tag:lab-apiserver` from the Tailscale client
- rely on the dedicated Headscale pre-auth key's `acl_tags` assignment, matching the existing hosted API-server pattern
- assert both sides of that contract

Headscale rejects client-requested ownership of the empty-owner tag, while the dedicated pre-auth key is already configured to apply it as a forced tag.

## Verification

- `fabric/cluster/lab/tests/run`
- `kubectl kustomize fabric/cluster/lab/foundation`
- `git diff --check`

## Rollout

I will merge this and continue watching the active lab foundation. The EtcdTenant is already Ready; the control-plane Kustomization remains suspended.