### PR TITLE
Activate the Fabric-hosted lab control plane

### DIFF
--- a/fabric/cluster/flux-system/children.yaml
+++ b/fabric/cluster/flux-system/children.yaml
@@ -255,7 +255,7 @@ spec:
   # Unsuspend only after fabric-lab-foundation is Ready. In particular, the
   # generated apiserver-etcd and lab-control-plane-endpoint values documents
   # must exist before Helm is allowed to render the control plane.
-  suspend: true
+  suspend: false
   dependsOn:
     - name: fabric-lab-foundation
   healthChecks:


### PR DESCRIPTION
## Summary

- unsuspend only `fabric-lab-control-plane`
- preserve the explicit dependency on `fabric-lab-foundation`

## Foundation gate verified live

- `EtcdTenant/lab/apiserver`: Ready
- `Deployment/lab-apiserver-tailnet`: 1/1 available on a Fabric service node
- `Deployment/lab-apiserver-endpoint-publisher`: 1/1 available
- published endpoint: `lab-apiserver.tailnet.hub.samcday.com` / `100.64.0.23`
- Headscale registration completed with the dedicated pre-auth key's forced tag

Flux still enforces same-revision foundation readiness before reconciling the HelmRelease.

## Verification

- `charts/k8s-control-plane/tests/run`
- `fabric/cluster/lab/tests/run`
- `kubectl kustomize fabric/cluster/flux-system`
- `kubectl kustomize fabric/cluster/lab/control-plane`
- `git diff --check`