### PR TITLE
Fix lab control-plane node affinity

### DIFF
--- a/fabric/cluster/lab/control-plane/control-plane-values.yaml
+++ b/fabric/cluster/lab/control-plane/control-plane-values.yaml
@@ -89,8 +89,8 @@ data:
           nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
               nodeSelectorTerms:
-                - matchFields:
-                    - key: metadata.name
+                - matchExpressions:
+                    - key: kubernetes.io/hostname
                       operator: In
                       values:
                         - fabric-az1-svc1

--- a/fabric/cluster/lab/tests/test_contract.py
+++ b/fabric/cluster/lab/tests/test_contract.py
@@ -151,6 +151,22 @@ class LabControlPlaneContract(unittest.TestCase):
         )
         self.assertEqual(values["apiServer"]["service"]["spec"]["clusterIP"], "172.21.0.25")
         self.assertTrue(values["parentWorkloads"]["enabled"])
+        term = values["parentWorkloads"]["placement"]["affinity"][
+            "nodeAffinity"
+        ]["requiredDuringSchedulingIgnoredDuringExecution"][
+            "nodeSelectorTerms"
+        ][0]
+        self.assertEqual(
+            term["matchExpressions"],
+            [
+                {
+                    "key": "kubernetes.io/hostname",
+                    "operator": "In",
+                    "values": ["fabric-az1-svc1", "fabric-az1-svc2"],
+                }
+            ],
+        )
+        self.assertNotIn("matchFields", term)
         self.assertEqual(
             values["parentWorkloads"]["deployment"]["pdb"]["spec"],
             {"minAvailable": 1},


### PR DESCRIPTION
## Summary

- select Fabric service nodes with `kubernetes.io/hostname` in the shared `parentWorkloads` placement
- replace the invalid multi-value `matchFields: metadata.name In` selector
- assert the rendered values contract contains no field selector

Helm's first install was rejected during server-side apply and uninstall remediation removed the partial release. No control-plane workloads were left running.

## Verification

- `charts/k8s-control-plane/tests/run`
- `fabric/cluster/lab/tests/run`
- `kubectl kustomize fabric/cluster/lab/control-plane`
- `git diff --check`

## Rollout

I will merge this and watch Helm's clean retry through Jobs, certificates, and replicated control-plane workloads.