### PR TITLE
Increase lab control-plane utility memory

### DIFF
--- a/fabric/cluster/lab/control-plane/control-plane-values.yaml
+++ b/fabric/cluster/lab/control-plane/control-plane-values.yaml
@@ -153,6 +153,6 @@ data:
           cpu: 10m
           memory: 32Mi
         limits:
-          memory: 128Mi
+          memory: 256Mi
       writableTmp: true
     version: 1.36.3

--- a/fabric/cluster/lab/tests/test_contract.py
+++ b/fabric/cluster/lab/tests/test_contract.py
@@ -173,6 +173,9 @@ class LabControlPlaneContract(unittest.TestCase):
         )
         self.assertFalse(values["monitoring"]["podMonitors"]["enabled"])
         self.assertEqual(values["konnectivity"]["server"]["clientIdentity"], "dedicated")
+        self.assertEqual(
+            values["utilities"]["resources"]["limits"]["memory"], "256Mi"
+        )
         for component in ("apiServer", "controllerManager", "scheduler"):
             self.assertRegex(
                 values[component]["image"]["digest"], r"^sha256:[0-9a-f]{64}$"


### PR DESCRIPTION
## Summary

- raise the lab control-plane utility container memory limit from 128Mi to 256Mi
- pin the value in the lab contract test

The control-plane Deployments are all Ready and bootstrap/CA-hash completed, but the initial admin-kubeconfig Job is repeatedly OOM-killed while flattening its kubeconfigs at 128Mi.

## Verification

- `charts/k8s-control-plane/tests/run`
- `fabric/cluster/lab/tests/run`
- `kubectl kustomize fabric/cluster/lab/control-plane`
- `git diff --check`

## Rollout

I will merge this and watch Helm replace the run-once Job at the next release revision, then verify the full HelmRelease and Flux Kustomization.