### PR TITLE
Add lab kubeconfig access

### DIFF
--- a/credhelper/src/config.rs
+++ b/credhelper/src/config.rs
@@ -5,6 +5,8 @@ use std::process::Command;
 pub const HUB_SERVER_URL: &str = "https://hub-apiserver.tailnet.hub.samcday.com:6443";
 pub const HUB_SERVER_TLS_NAME: &str = "10.0.1.254";
 pub const CLOUD_SERVER_URL: &str = "https://cloud-cluster-apiserver.tailnet.hub.samcday.com:6443";
+pub const FABRIC_SERVER_URL: &str = "https://10.66.0.254:6443";
+pub const FABRIC_SERVER_TLS_NAME: &str = "api.fabric.internal";
 pub const CERT_VALIDITY_DAYS: u32 = 1;
 pub const CACHE_EXPIRY_MARGIN_SECS: i64 = 300;
 pub const CERT_SUBJECT_CN: &str = "kubernetes-admin";
@@ -14,12 +16,13 @@ pub fn child_namespace(cluster: &str) -> Option<&'static str> {
     match cluster {
         "cloud" => Some("cloud-cluster"),
         "edge-au-east" => Some("edge"),
+        "lab" => Some("lab"),
         _ => None,
     }
 }
 
 pub fn all_child_clusters() -> &'static [&'static str] {
-    &["cloud", "edge-au-east"]
+    &["cloud", "edge-au-east", "lab"]
 }
 
 pub fn cache_root() -> PathBuf {

--- a/credhelper/src/kube_client.rs
+++ b/credhelper/src/kube_client.rs
@@ -1,21 +1,57 @@
 use anyhow::{Context, Result, bail};
 use k8s_openapi::api::core::v1::Secret;
 use kube::api::Api;
-use kube::config::{AuthInfo, Cluster, KubeConfigOptions, Kubeconfig, NamedAuthInfo, NamedCluster, NamedContext};
+use kube::config::{
+    AuthInfo, Cluster, ExecConfig, ExecInteractiveMode, KubeConfigOptions, Kubeconfig,
+    NamedAuthInfo, NamedCluster, NamedContext,
+};
 use kube::{Client, Config};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+pub enum ParentAuth {
+    CertificateFiles {
+        client_cert: PathBuf,
+        client_key: PathBuf,
+    },
+    Exec {
+        command: PathBuf,
+    },
+}
 
 pub async fn fetch_ca_secret(
     server_url: &str,
     server_tls_name: Option<&str>,
     server_ca_path: &Path,
-    client_cert_path: &Path,
-    client_key_path: &Path,
+    parent_auth: ParentAuth,
     namespace: &str,
 ) -> Result<(Vec<u8>, Vec<u8>)> {
+    let auth_info = match parent_auth {
+        ParentAuth::CertificateFiles {
+            client_cert,
+            client_key,
+        } => AuthInfo {
+            client_certificate: Some(client_cert.to_string_lossy().to_string()),
+            client_key: Some(client_key.to_string_lossy().to_string()),
+            ..Default::default()
+        },
+        ParentAuth::Exec { command } => AuthInfo {
+            exec: Some(ExecConfig {
+                api_version: Some("client.authentication.k8s.io/v1".to_string()),
+                command: Some(command.to_string_lossy().to_string()),
+                args: None,
+                env: None,
+                drop_env: None,
+                interactive_mode: Some(ExecInteractiveMode::Never),
+                provide_cluster_info: false,
+                cluster: None,
+            }),
+            ..Default::default()
+        },
+    };
+
     let kubeconfig = Kubeconfig {
         clusters: vec![NamedCluster {
-            name: "hub".to_string(),
+            name: "parent".to_string(),
             cluster: Some(Cluster {
                 server: Some(server_url.to_string()),
                 tls_server_name: server_tls_name.map(str::to_string),
@@ -24,23 +60,19 @@ pub async fn fetch_ca_secret(
             }),
         }],
         auth_infos: vec![NamedAuthInfo {
-            name: "hub-admin".to_string(),
-            auth_info: Some(AuthInfo {
-                client_certificate: Some(client_cert_path.to_string_lossy().to_string()),
-                client_key: Some(client_key_path.to_string_lossy().to_string()),
-                ..Default::default()
-            }),
+            name: "parent-admin".to_string(),
+            auth_info: Some(auth_info),
         }],
         contexts: vec![NamedContext {
-            name: "hub".to_string(),
+            name: "parent".to_string(),
             context: Some(kube::config::Context {
-                cluster: "hub".to_string(),
-                user: Some("hub-admin".to_string()),
+                cluster: "parent".to_string(),
+                user: Some("parent-admin".to_string()),
                 namespace: Some(namespace.to_string()),
                 ..Default::default()
             }),
         }],
-        current_context: Some("hub".to_string()),
+        current_context: Some("parent".to_string()),
         ..Default::default()
     };
 
@@ -49,7 +81,7 @@ pub async fn fetch_ca_secret(
         &KubeConfigOptions::default(),
     )
     .await
-    .context("failed to build kube config from cert files")?;
+    .context("failed to build parent kube config")?;
 
     let client = Client::try_from(config)
         .context("failed to create kube client")?;

--- a/credhelper/src/main.rs
+++ b/credhelper/src/main.rs
@@ -86,7 +86,10 @@ async fn ensure_child_credentials(cluster: &str, init: bool) -> Result<cache::Ca
 
     let paths = cache::CachePaths::for_cluster(cluster);
     let root = config::repo_root()?;
-    let repo_server_ca = root.join(format!("hub/pki/k8s/{cluster}-server-ca.crt"));
+    let repo_server_ca = match cluster {
+        "lab" => root.join("fabric/pki/k8s/lab-server-ca.crt"),
+        _ => root.join(format!("hub/pki/k8s/{cluster}-server-ca.crt")),
+    };
 
     let cache_ok = cache::is_valid(&paths) && paths.server_ca.exists();
 
@@ -96,7 +99,7 @@ async fn ensure_child_credentials(cluster: &str, init: bool) -> Result<cache::Ca
 
     if cache_ok && !repo_server_ca.exists() {
         eprintln!(
-            "warning: repo server CA missing at {}, re-fetching from hub API...",
+            "warning: repo server CA missing at {}, re-fetching from parent API...",
             repo_server_ca.display()
         );
     }
@@ -108,7 +111,7 @@ async fn ensure_child_credentials(cluster: &str, init: bool) -> Result<cache::Ca
         );
     }
 
-    let (parent_server_url, parent_server_tls_name, parent_server_ca, parent_paths) = match cluster {
+    let (parent_server_url, parent_server_tls_name, parent_server_ca, parent_auth) = match cluster {
         "cloud" => {
             let hub_paths = ensure_hub_credentials()?;
             let hub_server_ca = root.join("hub/pki/k8s/server-ca.crt");
@@ -116,13 +119,36 @@ async fn ensure_child_credentials(cluster: &str, init: bool) -> Result<cache::Ca
                 config::HUB_SERVER_URL,
                 Some(config::HUB_SERVER_TLS_NAME),
                 hub_server_ca,
-                hub_paths,
+                kube_client::ParentAuth::CertificateFiles {
+                    client_cert: hub_paths.client_cert,
+                    client_key: hub_paths.client_key,
+                },
             )
         }
         "edge-au-east" => {
             let cloud_paths = Box::pin(ensure_child_credentials("cloud", init)).await?;
             let cloud_server_ca = root.join("hub/pki/k8s/cloud-server-ca.crt");
-            (config::CLOUD_SERVER_URL, None, cloud_server_ca, cloud_paths)
+            (
+                config::CLOUD_SERVER_URL,
+                None,
+                cloud_server_ca,
+                kube_client::ParentAuth::CertificateFiles {
+                    client_cert: cloud_paths.client_cert,
+                    client_key: cloud_paths.client_key,
+                },
+            )
+        }
+        "lab" => {
+            let fabric_server_ca = root.join("fabric/access/server-ca.crt");
+            let fabric_credential = root.join("scripts/fabric-credential");
+            (
+                config::FABRIC_SERVER_URL,
+                Some(config::FABRIC_SERVER_TLS_NAME),
+                fabric_server_ca,
+                kube_client::ParentAuth::Exec {
+                    command: fabric_credential,
+                },
+            )
         }
         _ => bail!("unsupported child cluster: {cluster}"),
     };
@@ -131,8 +157,7 @@ async fn ensure_child_credentials(cluster: &str, init: bool) -> Result<cache::Ca
         parent_server_url,
         parent_server_tls_name,
         &parent_server_ca,
-        &parent_paths.client_cert,
-        &parent_paths.client_key,
+        parent_auth,
         namespace,
     )
     .await?;
@@ -150,6 +175,17 @@ async fn ensure_child_credentials(cluster: &str, init: bool) -> Result<cache::Ca
     cache::write_cert(&paths.client_cert, &client_cert_pem)?;
     cache::write_key(&paths.client_key, &client_key_pem)?;
     cache::write_cert(&paths.server_ca, &child_ca_cert_pem)?;
+    fs::create_dir_all(
+        repo_server_ca
+            .parent()
+            .context("repo server CA path has no parent directory")?,
+    )
+    .with_context(|| {
+        format!(
+            "failed to create repo server CA directory for {}",
+            repo_server_ca.display()
+        )
+    })?;
     cache::write_cert(&repo_server_ca, &child_ca_cert_pem)?;
 
     Ok(paths)
@@ -164,7 +200,8 @@ fn usage() {
 Clusters:
   hub
   cloud
-  edge-au-east"
+  edge-au-east
+  lab"
     );
 }
 

--- a/fabric/pki/k8s/.gitignore
+++ b/fabric/pki/k8s/.gitignore
@@ -1,0 +1,2 @@
+# Public child-cluster server CAs are populated by scripts/credhelper --init.
+*-server-ca.crt

--- a/kubeconfig
+++ b/kubeconfig
@@ -9,7 +9,8 @@ clusters:
       tls-server-name: 10.0.1.254
       certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJkakNDQVIyZ0F3SUJBZ0lCQURBS0JnZ3Foa2pPUFFRREFqQWpNU0V3SHdZRFZRUUREQmhyTTNNdGMyVnkKZG1WeUxXTmhRREUzTlRZM09UZ3lOak13SGhjTk1qVXdPVEF5TURjek1UQXpXaGNOTXpVd09ETXhNRGN6TVRBegpXakFqTVNFd0h3WURWUVFEREJock0zTXRjMlZ5ZG1WeUxXTmhRREUzTlRZM09UZ3lOak13V1RBVEJnY3Foa2pPClBRSUJCZ2dxaGtqT1BRTUJCd05DQUFSSERKd2tRbkQ4bEhKNU92dFdkWTQySzhDdzhDbDJBMUxsSlV5ZVQzcHIKMGdjNFJuWnNwelpEV0hKa09XUUhSSWo3MlMvbTkwQVhpbUJ2K2RjZDViVnhvMEl3UURBT0JnTlZIUThCQWY4RQpCQU1DQXFRd0R3WURWUjBUQVFIL0JBVXdBd0VCL3pBZEJnTlZIUTRFRmdRVVZMNmIxK0xoMzlFZ2hyMHhVSWZqCkk1amRjOWt3Q2dZSUtvWkl6ajBFQXdJRFJ3QXdSQUlnZlVmTld4NlVjL1Y0cjZmWjVKVUJ3b1JxZWdMMHp3R20KeDRZM3NhUXpkcHNDSUdoMHpiZCs4OVlic2Z3T0tqa1o1T0J1WTFjRG1veFV3V0x4Ri95SmdUK3MKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
   # Hub embeds certificate-authority-data inline because it is always present in-repo.
-  # Cloud uses a certificate-authority file path because its CA is fetched by `kube-credential-helper --init` from the hub API.
+  # Child clusters use certificate-authority file paths because their public CAs
+  # are fetched from the hosting cluster by `scripts/credhelper --init`.
   - name: cloud
     cluster:
       server: https://cloud-cluster-apiserver.tailnet.hub.samcday.com:6443
@@ -23,6 +24,10 @@ clusters:
       server: https://10.66.0.254:6443
       tls-server-name: api.fabric.internal
       certificate-authority: fabric/access/server-ca.crt
+  - name: lab
+    cluster:
+      server: https://lab-apiserver.tailnet.hub.samcday.com:6443
+      certificate-authority: fabric/pki/k8s/lab-server-ca.crt
 users:
   - name: hub-admin
     user:
@@ -54,6 +59,13 @@ users:
           - -c
           - 'exec "${FABRIC_INFRA_ROOT:-$HOME/src/infra}/scripts/fabric-credential"'
         interactiveMode: Never
+  - name: lab-admin
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1
+        command: ./scripts/credhelper
+        args: ["lab"]
+        interactiveMode: Never
 contexts:
   - name: hub
     context:
@@ -71,4 +83,8 @@ contexts:
     context:
       cluster: fabric
       user: fabric-operator
+  - name: lab
+    context:
+      cluster: lab
+      user: lab-admin
 current-context: fabric

--- a/scripts/ik
+++ b/scripts/ik
@@ -1,13 +1,14 @@
 #!/bin/bash
 # ik - infra kubectl
 # Runs kubectl against the multi-cluster infra kubeconfig.
-# Works from any directory. Contexts: hub, cloud, edge-au-east, fabric
+# Works from any directory. Contexts: hub, cloud, edge-au-east, fabric, lab
 #
 # Usage:
 #   ik --context=hub get nodes
 #   ik --context=cloud get pods -n fastboop
 #   ik --context=edge-au-east get nodes
 #   ik --context=fabric get nodes
+#   ik --context=lab get nodes
 #   ik get pods -A   (explicitly defaults to hub)
 set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## What changed

- add a `lab` cluster, user, and context to the repository kubeconfig
- teach `credhelper` to bootstrap Fabric-hosted child clusters through Fabric's bounded operator exec credential
- keep the generated Lab API server CA public but untracked, matching the existing child-cluster credential model
- document `lab` in `scripts/ik`

## Why

The Fabric-hosted Lab control plane was live, but the repository kubeconfig had no way to reach it. `credhelper` only understood children hosted by Hub or Cloud, so it could not retrieve Lab's delegated CA and mint a short-lived administrator identity.

## Impact

After `scripts/credhelper --init`, `scripts/ik --context=lab ...` reaches the Lab API over its Tailnet endpoint without committing long-lived credentials.

## Validation

- `cargo test --manifest-path credhelper/Cargo.toml --locked`
- `cargo clippy --manifest-path credhelper/Cargo.toml --all-targets --locked -- -D warnings`
- `fabric/cluster/lab/tests/run`
- `scripts/credhelper --init`
- `scripts/ik --context=lab get --raw=/readyz`
- `scripts/ik --context=lab get namespaces -o name`
- `scripts/ik --context=lab version`