### PR TITLE
Remove fastboop Matrix DNS

### DIFF
--- a/hub/cluster/cloud-cluster/nginx-gateway-shared.yaml
+++ b/hub/cluster/cloud-cluster/nginx-gateway-shared.yaml
@@ -105,14 +105,6 @@ spec:
             recordType: CNAME
             targets:
               - cloud.samcday.com
-          - dnsName: matrix.fastboop.win
-            providerSpecific:
-              - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
-                value: "false"
-            recordTTL: 300
-            recordType: CNAME
-            targets:
-              - cloud.samcday.com
           - dnsName: rokkitpokkit.samcday.com
             providerSpecific:
               - name: external-dns.alpha.kubernetes.io/cloudflare-proxied


### PR DESCRIPTION
## What changed

Remove the `matrix.fastboop.win` CNAME from the shared cloud gateway `DNSEndpoint`.

## Why

The corresponding Conduit Matrix homeserver is being decommissioned in `samcday/fastboop`.

## Impact

ExternalDNS will remove only `matrix.fastboop.win`. The apex, docs, www, wildcard certificate, fastboop tenant, and other shared gateway DNS records remain unchanged.

## Validation

- `kubectl kustomize hub/cluster/cloud-cluster`
- `helm template nginx-gateway-shared charts/resources` renders the remaining eight DNS names
- repository search confirms no remaining `matrix.fastboop.win` reference